### PR TITLE
Display __init__.py in source package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,7 @@ Changelog = "https://github.com/goldenm-software/layrz-sdk/blob/main/CHANGELOG.m
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = [
-  "layrz.*",
-  "layrz.__init__"
-]
+include = ["layrz"]
 namespaces = true
 
 [build-system]


### PR DESCRIPTION
This pull request includes a new attempt to display the __init__.py file in the source package. The changes made to the setup.cfg file include updating the include parameter to only include "layrz" and removing the "layrz.__init__" parameter. This should ensure that the __init__.py file is properly displayed in the source package.