### PR TITLE
Add permissions to build job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [ "main" ]
 
-permissions:
-  id-token: write
-  contents: read
-  repository-projects: read
-  packages: read
-
 jobs:
   build:
+    permissions:
+      id-token: write
+      contents: read
+      repository-projects: read
+      packages: read
+
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/goldenm-software/python-builder:3.11


### PR DESCRIPTION
This pull request adds permissions to the build job in order to allow it to write an id-token and read contents, repository-projects, and packages. This is necessary for the job to function properly.

Testing again