### PR TITLE
Add SensorType and SensorSubtype enums, update Sensor and SensorMask models

### DIFF
--- a/python/layrz_sdk/entities/__init__.py
+++ b/python/layrz_sdk/entities/__init__.py
@@ -94,6 +94,7 @@ from .report_row import ReportRow
 from .request_type import HttpRequestType
 from .sensor import Sensor
 from .sensor_mask import SensorMask
+from .sensor_type import SensorSubtype, SensorType
 from .sound_effect import SoundEffect
 from .static_position import StaticPosition
 from .telemetry import AssetMessage, DeviceMessage
@@ -227,4 +228,6 @@ __all__ = [
   'AtsOperation',
   'ParameterUpdate',
   'PushNotification',
+  'SensorType',
+  'SensorSubtype',
 ]

--- a/python/layrz_sdk/entities/sensor.py
+++ b/python/layrz_sdk/entities/sensor.py
@@ -1,7 +1,10 @@
 # go migrated
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .sensor_mask import SensorMask
+from .sensor_type import SensorSubtype, SensorType
 
 
 class Sensor(BaseModel):
@@ -19,14 +22,27 @@ class Sensor(BaseModel):
   )
   name: str = Field(description='Defines the name of the sensor')
   slug: str = Field(description='Defines the slug of the sensor')
+
+  type: SensorType = Field(description='Defines the type of the sensor', default=SensorType.UNKNOWN)
+  subtype: SensorSubtype = Field(description='Defines the subtype of the sensor', default=SensorSubtype.UNKNOWN)
+
   formula: str = Field(
     default='',
     description='Defines the formula of the sensor, used for calculations',
   )
-  mask: list[SensorMask] | None = Field(
-    default=None,
+
+  mask: list[SensorMask] = Field(
+    default_factory=list,
     description='Defines the mask of the sensor, used for filtering data',
   )
+
+  @field_validator('mask', mode='before')
+  @classmethod
+  def validate_mask(cls, v: Any) -> list[SensorMask]:
+    """Validates the mask of the sensor, ensuring it is a list of SensorMask"""
+    if v is None:
+      return []
+    return v
 
   measuring_unit: str | None = Field(
     default=None,

--- a/python/layrz_sdk/entities/sensor_mask.py
+++ b/python/layrz_sdk/entities/sensor_mask.py
@@ -1,5 +1,7 @@
 # go migrated
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class SensorMask(BaseModel):
@@ -27,3 +29,16 @@ class SensorMask(BaseModel):
     default=None,
     description='Defines the value of the sensor, can be of various types',
   )
+
+  @field_validator('value', mode='before')
+  @classmethod
+  def validate_value(cls, v: Any) -> str | float | int | None:
+    """Validates the value of the sensor mask, ensuring it is of the correct type"""
+    if isinstance(v, str):
+      if v.isdigit():
+        try:
+          return float(v)
+        except ValueError:
+          return v
+
+    return v

--- a/python/layrz_sdk/entities/sensor_type.py
+++ b/python/layrz_sdk/entities/sensor_type.py
@@ -1,0 +1,41 @@
+from enum import StrEnum
+
+
+class SensorType(StrEnum):
+  """
+  Sensor type, read the comments for more information
+  """
+
+  CONSTANT = 'CONSTANT'
+  ACCUMULATOR = 'ACCUMULATOR'
+  UNPACK = 'UNPACK'
+  AUTHENTICATION = 'AUTHENTICATION'
+  IMAGE = 'IMAGE'
+  LAMBDA = 'LAMBDA'
+  SCRIPT = 'SCRIPT'
+  DYNAMIC = 'DYNAMIC'
+  UNKNOWN = 'UNKNOWN'
+
+
+class SensorSubtype(StrEnum):
+  """
+  Sensor subtype, read the comments for more information
+  """
+
+  RAW = 'RAW'
+  INTERVAL = 'INTERVAL'
+  CONDITION = 'CONDITION'
+  MESSAGE = 'MESSAGE'
+  DRIVER = 'DRIVER'
+  PASSENGER = 'PASSENGER'
+  OPERATOR = 'OPERATOR'
+  CSV = 'CSV'
+  JSON = 'JSON'
+  XML = 'XML'
+  BASE64 = 'BASE64'
+  FLESPI = 'FLESPI'
+  LAYRZ = 'LAYRZ'
+  UNUSED = 'UNUSED'
+  PYTHON = 'PYTHON'
+  V8 = 'V8'
+  UNKNOWN = 'UNKNOWN'

--- a/python/tests/test_sensor.py
+++ b/python/tests/test_sensor.py
@@ -20,7 +20,7 @@ def test_sensor() -> None:
   assert sensor.slug == 'speed'
   assert sensor.formula == 'GET_PARAM("position.speed", 0)'
   assert sensor.measuring_unit == 'km/h'
-  assert sensor.mask is not None
+  assert isinstance(sensor.mask, list)
   assert len(sensor.mask) == 2
   assert sensor.mask[0].text == 'Low'
 
@@ -30,5 +30,6 @@ def test_sensor_minimal() -> None:
   sensor = Sensor.model_validate(data)
 
   assert sensor.formula == ''
-  assert sensor.mask is None
+  assert isinstance(sensor.mask, list)
+  assert len(sensor.mask) == 0
   assert sensor.measuring_unit is None


### PR DESCRIPTION
Introduce SensorType and SensorSubtype enums to categorize sensor types and subtypes. Update the Sensor and SensorMask models to incorporate these enums and enhance validation for the mask and value fields.