### PR TITLE
feat: add optimize_line_chart helper using LTTB downsampling

### DIFF
--- a/python/layrz_sdk/entities/__init__.py
+++ b/python/layrz_sdk/entities/__init__.py
@@ -27,6 +27,10 @@ from .broadcast import (
 from .case import Case
 from .case_ignored_status import CaseIgnoredStatus
 from .case_status import CaseStatus
+from .chart import Chart
+from .chart_algorithm import ChartAlgorithm
+from .chart_data_source import ChartDataSource
+from .chart_type import ChartType
 from .charts.axis_config import AxisConfig
 from .charts.bar_chart import BarChart
 from .charts.chart_alignment import ChartAlignment
@@ -134,6 +138,10 @@ __all__ = [
   'Case',
   'CaseIgnoredStatus',
   'CaseStatus',
+  'Chart',
+  'ChartAlgorithm',
+  'ChartDataSource',
+  'ChartType',
   'ChartAlignment',
   'ChartColor',
   'ChartConfiguration',

--- a/python/layrz_sdk/entities/chart.py
+++ b/python/layrz_sdk/entities/chart.py
@@ -1,0 +1,25 @@
+"""Chart entity"""
+
+from pydantic import BaseModel, Field
+
+from .chart_algorithm import ChartAlgorithm
+from .chart_data_source import ChartDataSource
+from .chart_type import ChartType
+
+
+class Chart(BaseModel):
+  """Represents a chart configuration object"""
+
+  id: int = Field(description='Chart ID')
+  name: str = Field(description='Chart name')
+  description: str | None = Field(default=None, description='Chart description')
+
+  chart: ChartType = Field(description='Chart type')
+  algorithm: ChartAlgorithm = Field(description='Algorithm used to compute the chart data')
+  data_source: ChartDataSource = Field(description='Data source used to feed the chart')
+
+  script: str | None = Field(default=None, description='Python script for PYTHON algorithm charts')
+  sensors: list[str] = Field(default_factory=list, description='Sensor slugs for AUTO algorithm charts')
+  enable_lttb: bool = Field(default=True, description='Whether LTTB downsampling is enabled')
+
+  asset_ids: list[int] = Field(default_factory=list, description='IDs of assets bound to this chart')

--- a/python/layrz_sdk/entities/chart_algorithm.py
+++ b/python/layrz_sdk/entities/chart_algorithm.py
@@ -1,0 +1,11 @@
+"""Chart algorithm enum"""
+
+from strenum import StrEnum
+
+
+class ChartAlgorithm(StrEnum):
+  """Algorithm used to compute the chart data"""
+
+  PYTHON = 'PYTHON'
+  LCL = 'LCL'
+  AUTO = 'AUTO'

--- a/python/layrz_sdk/entities/chart_data_source.py
+++ b/python/layrz_sdk/entities/chart_data_source.py
@@ -1,0 +1,17 @@
+"""Chart data source enum"""
+
+from strenum import StrEnum
+
+
+class ChartDataSource(StrEnum):
+  """Data source used to feed the chart"""
+
+  MESSAGES = 'MESSAGES'
+  EVENTS = 'EVENTS'
+  CASES = 'CASES'
+  CHECKPOINTS = 'CHECKPOINTS'
+  CORE_PROCESSES = 'CORE_PROCESSES'
+  ATS_OPERATIONS = 'ATS_OPERATIONS'
+  ATS_PURCHASEORDERS = 'ATS_PURCHASEORDERS'
+  LAST_MESSAGES = 'LAST_MESSAGES'
+  LAST_EVENTS = 'LAST_EVENTS'

--- a/python/layrz_sdk/entities/chart_type.py
+++ b/python/layrz_sdk/entities/chart_type.py
@@ -1,0 +1,21 @@
+"""Chart type enum"""
+
+from strenum import StrEnum
+
+
+class ChartType(StrEnum):
+  """Available chart types"""
+
+  PIE = 'PIE'
+  BAR = 'BAR'
+  LINE = 'LINE'
+  AREA = 'AREA'
+  COLUMN = 'COLUMN'
+  RADIALBAR = 'RADIALBAR'
+  SCATTER = 'SCATTER'
+  TIMELINE = 'TIMELINE'
+  RADAR = 'RADAR'
+  MAP = 'MAP'
+  HTML = 'HTML'
+  NUMBER = 'NUMBER'
+  TABLE = 'TABLE'

--- a/python/layrz_sdk/helpers/__init__.py
+++ b/python/layrz_sdk/helpers/__init__.py
@@ -1,7 +1,10 @@
+from .charts import DEFAULT_TARGET, optimize_line_chart
 from .color import convert_to_rgba, use_black
 from .uuid import compose_uuid, extract_timestamp_from_uuidv7
 
 __all__ = [
+  'DEFAULT_TARGET',
+  'optimize_line_chart',
   'convert_to_rgba',
   'use_black',
   'compose_uuid',

--- a/python/layrz_sdk/helpers/charts.py
+++ b/python/layrz_sdk/helpers/charts.py
@@ -80,7 +80,7 @@ def _to_float_xs(serie: ChartDataSerie) -> list[float]:
   return result
 
 
-def optimize_line_chart(chart: LineChart, width_px: int | None = None) -> LineChart:
+def optimize_line_chart(chart: LineChart, width_px: int | None = None, enable_lttb: bool = True) -> LineChart:
   """
   Downsample a LineChart using the LTTB (Largest Triangle Three Buckets) algorithm.
 
@@ -92,8 +92,12 @@ def optimize_line_chart(chart: LineChart, width_px: int | None = None) -> LineCh
 
   :param chart: The LineChart to downsample.
   :param width_px: Target number of data points (physical pixels). Defaults to 1000.
+  :param enable_lttb: When False, skips downsampling entirely and returns the original chart.
   :return: A new LineChart instance with downsampled data (or the original if no downsampling needed).
   """
+  if not enable_lttb:
+    return chart
+
   target = width_px if width_px is not None else DEFAULT_TARGET
 
   eligible_indices = [

--- a/python/layrz_sdk/helpers/charts.py
+++ b/python/layrz_sdk/helpers/charts.py
@@ -1,0 +1,128 @@
+"""Chart helpers"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from layrz_sdk.entities.charts.chart_data_serie_type import ChartDataSerieType
+from layrz_sdk.entities.charts.chart_data_type import ChartDataType
+
+if TYPE_CHECKING:
+  from layrz_sdk.entities.charts.chart_data_serie import ChartDataSerie
+  from layrz_sdk.entities.charts.line_chart import LineChart
+
+DEFAULT_TARGET = 1000
+
+_ELIGIBLE_SERIE_TYPES = {ChartDataSerieType.LINE, ChartDataSerieType.AREA, ChartDataSerieType.SCATTER}
+
+
+def _lttb(xs: list[float], ys: list[float], target: int) -> list[int]:
+  """
+  Largest Triangle Three Buckets downsampling algorithm.
+  Returns the indices of the selected points.
+  Always keeps the first and last points.
+  """
+  n = len(xs)
+  if n <= target:
+    return list(range(n))
+
+  indices: list[int] = [0]
+  bucket_size = (n - 2) / (target - 2)
+
+  for i in range(1, target - 1):
+    a = indices[-1]
+
+    range_start = int(math.floor((i - 1) * bucket_size)) + 1
+    range_end = min(int(math.floor(i * bucket_size)) + 1, n - 1)
+
+    next_start = range_end
+    next_end = min(int(math.floor((i + 1) * bucket_size)) + 1, n - 1)
+
+    bucket_len = next_end - next_start
+    if bucket_len == 0:
+      avg_x = xs[next_start]
+      avg_y = ys[next_start]
+    else:
+      avg_x = sum(xs[next_start:next_end]) / bucket_len
+      avg_y = sum(ys[next_start:next_end]) / bucket_len
+
+    ax, ay = xs[a], ys[a]
+
+    max_area = -1.0
+    best = range_start
+    for j in range(range_start, range_end):
+      area = abs((ax - avg_x) * (ys[j] - ay) - (ax - xs[j]) * (avg_y - ay)) * 0.5
+      if area > max_area:
+        max_area = area
+        best = j
+
+    indices.append(best)
+
+  indices.append(n - 1)
+  return indices
+
+
+def _to_float_xs(serie: ChartDataSerie) -> list[float]:
+  """Convert x_axis data to floats for LTTB."""
+  result: list[float] = []
+  for i, x in enumerate(serie.data):
+    if serie.data_type == ChartDataType.DATETIME:
+      if isinstance(x, datetime):
+        result.append(x.timestamp())
+      else:
+        result.append(float(x))
+    elif serie.data_type == ChartDataType.NUMBER:
+      result.append(float(x))
+    else:
+      result.append(float(i))
+  return result
+
+
+def optimize_line_chart(chart: LineChart, width_px: int | None = None) -> LineChart:
+  """
+  Downsample a LineChart using the LTTB (Largest Triangle Three Buckets) algorithm.
+
+  Only Y axis series with serie_type in {LINE, AREA, SCATTER} and data_type == NUMBER are
+  downsampled. Series with serie_type == NONE are passed through unchanged.
+
+  The selected X indices are determined from the first eligible Y series and applied
+  consistently to all eligible series and to x_axis.data.
+
+  :param chart: The LineChart to downsample.
+  :param width_px: Target number of data points (physical pixels). Defaults to 1000.
+  :return: A new LineChart instance with downsampled data (or the original if no downsampling needed).
+  """
+  target = width_px if width_px is not None else DEFAULT_TARGET
+
+  eligible_indices = [
+    i
+    for i, s in enumerate(chart.y_axis)
+    if s.serie_type in _ELIGIBLE_SERIE_TYPES and s.data_type == ChartDataType.NUMBER
+  ]
+
+  if not eligible_indices:
+    return chart
+
+  first_eligible = chart.y_axis[eligible_indices[0]]
+  if len(first_eligible.data) <= target:
+    return chart
+
+  xs_float = _to_float_xs(chart.x_axis)
+  ys_float = [float(v) for v in first_eligible.data]
+
+  selected = _lttb(xs_float, ys_float, target)
+
+  new_x_data = [chart.x_axis.data[i] for i in selected]
+  new_x_axis = chart.x_axis.model_copy(update={'data': new_x_data})
+
+  new_y_axis: list[ChartDataSerie] = []
+  for idx, serie in enumerate(chart.y_axis):
+    if idx in eligible_indices:
+      new_y_data = [serie.data[i] for i in selected]
+      new_y_axis.append(serie.model_copy(update={'data': new_y_data}))
+    else:
+      new_y_axis.append(serie)
+
+  return chart.model_copy(update={'x_axis': new_x_axis, 'y_axis': new_y_axis})

--- a/python/tests/test_chart_helpers.py
+++ b/python/tests/test_chart_helpers.py
@@ -1,0 +1,168 @@
+"""Tests for optimize_line_chart (LTTB downsampling)."""
+
+from datetime import datetime, timezone
+
+from layrz_sdk.entities.charts.chart_data_serie import ChartDataSerie
+from layrz_sdk.entities.charts.chart_data_serie_type import ChartDataSerieType
+from layrz_sdk.entities.charts.chart_data_type import ChartDataType
+from layrz_sdk.entities.charts.line_chart import LineChart
+from layrz_sdk.helpers import DEFAULT_TARGET, optimize_line_chart
+
+
+def _make_chart(
+  n: int,
+  x_data_type: ChartDataType = ChartDataType.NUMBER,
+  y_serie_types: list[ChartDataSerieType] | None = None,
+  y_data_types: list[ChartDataType] | None = None,
+) -> LineChart:
+  """Helper to build a LineChart with n points and one or more Y series."""
+  if y_serie_types is None:
+    y_serie_types = [ChartDataSerieType.LINE]
+  if y_data_types is None:
+    y_data_types = [ChartDataType.NUMBER] * len(y_serie_types)
+
+  if x_data_type == ChartDataType.DATETIME:
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    x_data = [base.replace(second=i % 60, minute=(i // 60) % 60, hour=(i // 3600) % 24) for i in range(n)]
+  else:
+    x_data = list(range(n))
+
+  x_axis = ChartDataSerie(data=x_data, data_type=x_data_type, serie_type=ChartDataSerieType.NONE)
+
+  y_axis = [
+    ChartDataSerie(
+      data=[float(i) * (j + 1) for i in range(n)],
+      data_type=y_data_types[j],
+      serie_type=y_serie_types[j],
+    )
+    for j in range(len(y_serie_types))
+  ]
+
+  return LineChart(x_axis=x_axis, y_axis=y_axis)
+
+
+def test_passthrough_no_eligible() -> None:
+  """All Y series are NONE type — chart returned unchanged (same object)."""
+  chart = _make_chart(5000, y_serie_types=[ChartDataSerieType.NONE])
+  result = optimize_line_chart(chart, width_px=500)
+  assert result is chart
+
+
+def test_passthrough_below_threshold() -> None:
+  """Series has fewer points than target — returned unchanged (same object)."""
+  chart = _make_chart(10)
+  result = optimize_line_chart(chart, width_px=1000)
+  assert result is chart
+
+
+def test_passthrough_equal_threshold() -> None:
+  """Series has exactly target points — returned unchanged (same object)."""
+  chart = _make_chart(500)
+  result = optimize_line_chart(chart, width_px=500)
+  assert result is chart
+
+
+def test_lttb_reduces_points() -> None:
+  """5000-point series downsampled to width_px=500 produces exactly 500 points."""
+  chart = _make_chart(5000)
+  result = optimize_line_chart(chart, width_px=500)
+  assert len(result.x_axis.data) == 500
+  assert len(result.y_axis[0].data) == 500
+
+
+def test_lttb_keeps_first_and_last() -> None:
+  """LTTB always preserves the first and last data points."""
+  chart = _make_chart(5000)
+  result = optimize_line_chart(chart, width_px=500)
+
+  assert result.x_axis.data[0] == chart.x_axis.data[0]
+  assert result.x_axis.data[-1] == chart.x_axis.data[-1]
+  assert result.y_axis[0].data[0] == chart.y_axis[0].data[0]
+  assert result.y_axis[0].data[-1] == chart.y_axis[0].data[-1]
+
+
+def test_consistent_indices_across_series() -> None:
+  """Two eligible Y series share the same selected X indices after downsampling."""
+  chart = _make_chart(5000, y_serie_types=[ChartDataSerieType.LINE, ChartDataSerieType.AREA])
+  result = optimize_line_chart(chart, width_px=500)
+
+  # Both y series and x_axis must have same length
+  assert len(result.x_axis.data) == len(result.y_axis[0].data) == len(result.y_axis[1].data)
+
+  # Verify that indices chosen are the same for both series by checking x correspondence
+  # (Since both series were downsampled together using the same indices, their values
+  # should be a consistent subset of the original data.)
+  original_x = chart.x_axis.data
+  original_y0 = chart.y_axis[0].data
+  original_y1 = chart.y_axis[1].data
+
+  for rx, ry0, ry1 in zip(result.x_axis.data, result.y_axis[0].data, result.y_axis[1].data, strict=True):
+    idx = original_x.index(rx)
+    assert original_y0[idx] == ry0
+    assert original_y1[idx] == ry1
+
+
+def test_non_eligible_series_passthrough() -> None:
+  """NONE-type series data is passed through untouched while eligible series are downsampled."""
+  chart = _make_chart(
+    5000,
+    y_serie_types=[ChartDataSerieType.LINE, ChartDataSerieType.NONE],
+    y_data_types=[ChartDataType.NUMBER, ChartDataType.NUMBER],
+  )
+  result = optimize_line_chart(chart, width_px=500)
+
+  # Eligible series is downsampled
+  assert len(result.y_axis[0].data) == 500
+  # NONE series is unchanged
+  assert result.y_axis[1].data is chart.y_axis[1].data
+
+
+def test_default_target_used_when_none() -> None:
+  """width_px=None uses DEFAULT_TARGET (1000)."""
+  n = DEFAULT_TARGET + 500
+  chart = _make_chart(n)
+  result = optimize_line_chart(chart, width_px=None)
+  assert len(result.x_axis.data) == DEFAULT_TARGET
+
+
+def test_does_not_mutate_input() -> None:
+  """optimize_line_chart must not modify the original chart."""
+  chart = _make_chart(5000)
+  original_x_len = len(chart.x_axis.data)
+  original_y_len = len(chart.y_axis[0].data)
+
+  optimize_line_chart(chart, width_px=500)
+
+  assert len(chart.x_axis.data) == original_x_len
+  assert len(chart.y_axis[0].data) == original_y_len
+
+
+def test_datetime_x_axis() -> None:
+  """LTTB works correctly when x_axis.data_type is DATETIME."""
+  chart = _make_chart(5000, x_data_type=ChartDataType.DATETIME)
+  result = optimize_line_chart(chart, width_px=500)
+  assert len(result.x_axis.data) == 500
+  assert result.x_axis.data[0] == chart.x_axis.data[0]
+  assert result.x_axis.data[-1] == chart.x_axis.data[-1]
+
+
+def test_scatter_type_eligible() -> None:
+  """SCATTER serie_type with NUMBER data_type is eligible for downsampling."""
+  chart = _make_chart(5000, y_serie_types=[ChartDataSerieType.SCATTER])
+  result = optimize_line_chart(chart, width_px=500)
+  assert len(result.y_axis[0].data) == 500
+
+
+def test_non_number_data_type_passthrough() -> None:
+  """A LINE series with data_type != NUMBER is not eligible and passes through unchanged."""
+  chart = _make_chart(
+    5000,
+    y_serie_types=[ChartDataSerieType.LINE, ChartDataSerieType.LINE],
+    y_data_types=[ChartDataType.NUMBER, ChartDataType.STRING],
+  )
+  result = optimize_line_chart(chart, width_px=500)
+
+  # NUMBER series is downsampled
+  assert len(result.y_axis[0].data) == 500
+  # STRING series is unchanged
+  assert result.y_axis[1].data is chart.y_axis[1].data

--- a/python/tests/test_chart_helpers.py
+++ b/python/tests/test_chart_helpers.py
@@ -153,6 +153,13 @@ def test_scatter_type_eligible() -> None:
   assert len(result.y_axis[0].data) == 500
 
 
+def test_lttb_disabled_returns_original() -> None:
+  """enable_lttb=False skips downsampling entirely and returns the same object."""
+  chart = _make_chart(5000)
+  result = optimize_line_chart(chart, width_px=500, enable_lttb=False)
+  assert result is chart
+
+
 def test_non_number_data_type_passthrough() -> None:
   """A LINE series with data_type != NUMBER is not eligible and passes through unchanged."""
   chart = _make_chart(


### PR DESCRIPTION
## 📋 Summary

- Adds `optimize_line_chart()` to `layrz_sdk.helpers` to reduce `LineChart` data points before rendering using the **LTTB (Largest Triangle Three Buckets)** algorithm (Steinarsson 2013)
- Designed for Flutter consumers: `width_px` is passed in physical pixels (already scaled by `devicePixelRatio`); defaults to 1000 when `None`
- Returns a new `LineChart` instance — the input is never mutated

## ✨ Features

- **`optimize_line_chart(chart, width_px, enable_lttb=True)`** — downsamples eligible Y axis series to at most `width_px` points
  - Eligible series: `serie_type` in `{LINE, AREA, SCATTER}` and `data_type == NUMBER`
  - `NONE`-type and non-`NUMBER` series pass through unchanged
  - X indices are derived from the first eligible Y series and applied consistently across all eligible series and `x_axis.data`
  - Supports `DATETIME` and `NUMBER` x-axis data types
  - Returns the original chart object unchanged if no eligible series exist or the series is already within the target size
  - **`enable_lttb=False`** skips downsampling entirely and returns the original chart object — useful for callers that need to conditionally disable the algorithm at runtime
- **`DEFAULT_TARGET = 1000`** exported from `layrz_sdk.helpers`
- 13 tests in `python/tests/test_chart_helpers.py` covering passthrough cases, reduction, first/last preservation, cross-series index consistency, datetime x-axis, no-mutation, non-eligible passthrough, and `enable_lttb=False` early-return

🤖 Generated with [Claude Code](https://claude.com/claude-code)