### PR TITLE
fix: resolve circular import in column_chart by lazily importing convert_to_rgba

### DIFF
--- a/python/layrz_sdk/entities/charts/column_chart.py
+++ b/python/layrz_sdk/entities/charts/column_chart.py
@@ -4,8 +4,6 @@ from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
-from layrz_sdk.helpers import convert_to_rgba
-
 from .axis_config import AxisConfig
 from .chart_alignment import ChartAlignment
 from .chart_data_serie import ChartDataSerie
@@ -143,6 +141,7 @@ class ColumnChart(BaseModel):
     """
     Converts the configuration of the chart to Javascript library ApexCharts.
     """
+    from layrz_sdk.helpers import convert_to_rgba
 
     series = []
     colors = []


### PR DESCRIPTION
## 📋 Summary

- `helpers/__init__` imports `helpers/charts`, which imports `entities` submodules; meanwhile `entities/charts/column_chart` imported `convert_to_rgba` from `layrz_sdk.helpers` at module level — creating a circular import that raised `ImportError: cannot import name 'convert_to_rgba' from partially initialized module 'layrz_sdk.helpers'`

## 🐛 Fixes

- Moved `from layrz_sdk.helpers import convert_to_rgba` inside `ColumnChart._render_apexcharts()` where it is actually used, breaking the circular dependency at import time

🤖 Generated with [Claude Code](https://claude.com/claude-code)