### PR TITLE
feat(charts): add decimals rounding to all chart types and export get_color_list

### DIFF
--- a/python/layrz_sdk/entities/__init__.py
+++ b/python/layrz_sdk/entities/__init__.py
@@ -34,7 +34,7 @@ from .chart_type import ChartType
 from .charts.axis_config import AxisConfig
 from .charts.bar_chart import BarChart
 from .charts.chart_alignment import ChartAlignment
-from .charts.chart_color import ChartColor
+from .charts.chart_color import ChartColor, get_color_list
 from .charts.chart_configuration import ChartConfiguration
 from .charts.chart_data_serie import ChartDataSerie
 from .charts.chart_data_serie_type import ChartDataSerieType
@@ -144,6 +144,7 @@ __all__ = [
   'ChartType',
   'ChartAlignment',
   'ChartColor',
+  'get_color_list',
   'ChartConfiguration',
   'ChartDataSerie',
   'ChartDataSerieType',

--- a/python/layrz_sdk/entities/charts/bar_chart.py
+++ b/python/layrz_sdk/entities/charts/bar_chart.py
@@ -88,7 +88,8 @@ class BarChart(BaseModel):
       values = []
       for i, value in enumerate(serie.data):
         x_axis = self.x_axis.data[i]
-        values.append({'xAxis': x_axis, 'yAxis': value})
+        y_value = round(float(value), serie.decimals) if isinstance(value, (int, float)) else value
+        values.append({'xAxis': x_axis, 'yAxis': y_value})
 
       series.append(
         {

--- a/python/layrz_sdk/entities/charts/chart_data_serie.py
+++ b/python/layrz_sdk/entities/charts/chart_data_serie.py
@@ -33,3 +33,4 @@ class ChartDataSerie(BaseModel):
     return data_type.value
 
   dashed: bool = Field(description='If the serie should be dashed', default=False)
+  decimals: int = Field(description='Number of decimal places to round numeric values to', default=3)

--- a/python/layrz_sdk/entities/charts/column_chart.py
+++ b/python/layrz_sdk/entities/charts/column_chart.py
@@ -88,7 +88,8 @@ class ColumnChart(BaseModel):
       values = []
       for i, value in enumerate(serie.data):
         x_axis = self.x_axis.data[i]
-        values.append({'xAxis': x_axis, 'yAxis': value})
+        y_value = round(float(value), serie.decimals) if isinstance(value, (int, float)) else value
+        values.append({'xAxis': x_axis, 'yAxis': y_value})
 
       series.append(
         {

--- a/python/layrz_sdk/entities/charts/line_chart.py
+++ b/python/layrz_sdk/entities/charts/line_chart.py
@@ -98,10 +98,7 @@ class LineChart(BaseModel):
 
         y_value = serie.data[i]
         if isinstance(y_value, bool):
-          if y_value:
-            y_value = 1
-          else:
-            y_value = 0
+          y_value = 1 if y_value else 0
 
         if not isinstance(y_value, (int, float)):
           log.debug("Value isn't a number: %s", y_value)
@@ -110,7 +107,7 @@ class LineChart(BaseModel):
         points.append(
           {
             'xAxis': x_value,
-            'yAxis': y_value,
+            'yAxis': round(float(y_value), serie.decimals),
           }
         )
 

--- a/python/layrz_sdk/entities/charts/number_chart.py
+++ b/python/layrz_sdk/entities/charts/number_chart.py
@@ -17,6 +17,7 @@ class NumberChart(BaseModel):
   value: float = Field(description='Value of the number')
   color: str = Field(description='Color of the number')
   label: str = Field(description='Label of the number')
+  decimals: int = Field(description='Number of decimal places to round the value to', default=3)
 
   def render(self: Self, technology: ChartRenderTechnology = ChartRenderTechnology.FLUTTER) -> dict[str, Any]:
     """
@@ -46,7 +47,7 @@ class NumberChart(BaseModel):
     Converts the configuration of the chart to a Flutter native components.
     """
     return {
-      'value': self.value,
+      'value': round(self.value, self.decimals),
       'color': self.color,
       'label': self.label,
     }

--- a/python/layrz_sdk/entities/charts/pie_chart.py
+++ b/python/layrz_sdk/entities/charts/pie_chart.py
@@ -71,11 +71,14 @@ class PieChart(BaseModel):
     series = []
 
     for serie in self.series:
+      value = serie.data[0]
+      if isinstance(value, (int, float)):
+        value = round(float(value), serie.decimals)
       series.append(
         {
           'label': serie.label,
           'color': serie.color,
-          'value': serie.data[0],
+          'value': value,
         }
       )
 
@@ -88,11 +91,14 @@ class PieChart(BaseModel):
     series = []
 
     for serie in self.series:
+      value = serie.data[0]
+      if isinstance(value, (int, float)):
+        value = round(float(value), serie.decimals)
       series.append(
         {
           'group': serie.label,
           'color': serie.color,
-          'value': serie.data[0],
+          'value': value,
         }
       )
 
@@ -108,7 +114,10 @@ class PieChart(BaseModel):
     labels = []
 
     for serie in self.series:
-      series.append(serie.data[0])
+      value = serie.data[0]
+      if isinstance(value, (int, float)):
+        value = round(float(value), serie.decimals)
+      series.append(value)
       colors.append(serie.color)
       labels.append(serie.label)
 

--- a/python/layrz_sdk/entities/charts/radial_bar_chart.py
+++ b/python/layrz_sdk/entities/charts/radial_bar_chart.py
@@ -71,11 +71,14 @@ class RadialBarChart(BaseModel):
     series = []
 
     for serie in self.series:
+      value = serie.data[0]
+      if isinstance(value, (int, float)):
+        value = round(float(value), serie.decimals)
       series.append(
         {
           'label': serie.label,
           'color': serie.color,
-          'value': serie.data[0],
+          'value': value,
         }
       )
 
@@ -88,11 +91,14 @@ class RadialBarChart(BaseModel):
     series = []
 
     for serie in self.series:
+      value = serie.data[0]
+      if isinstance(value, (int, float)):
+        value = round(float(value), serie.decimals)
       series.append(
         {
           'group': serie.label,
           'color': serie.color,
-          'value': serie.data[0],
+          'value': value,
         }
       )
 
@@ -108,7 +114,10 @@ class RadialBarChart(BaseModel):
     labels = []
 
     for serie in self.series:
-      series.append(serie.data[0])
+      value = serie.data[0]
+      if isinstance(value, (int, float)):
+        value = round(float(value), serie.decimals)
+      series.append(value)
       colors.append(serie.color)
       labels.append(serie.label)
 

--- a/python/layrz_sdk/entities/charts/scatter_chart.py
+++ b/python/layrz_sdk/entities/charts/scatter_chart.py
@@ -101,8 +101,8 @@ class ScatterChart(BaseModel):
 
         data.append(
           {
-            'xAxis': item.x,
-            'yAxis': item.y,
+            'xAxis': round(float(item.x), serie.decimals),
+            'yAxis': round(float(item.y), serie.decimals),
           }
         )
 

--- a/python/layrz_sdk/entities/charts/scatter_serie.py
+++ b/python/layrz_sdk/entities/charts/scatter_serie.py
@@ -17,6 +17,7 @@ class ScatterSerie(BaseModel):
   color: str = Field(description='Color of the serie', default='')
   label: str = Field(description='Label of the serie', default='')
   serie_type: ChartDataSerieType = Field(description='Type of the serie', default=ChartDataSerieType.SCATTER)
+  decimals: int = Field(description='Number of decimal places to round numeric values to', default=3)
 
   @field_serializer('serie_type', when_used='always')
   def serialize_serie_type(self, serie_type: ChartDataSerieType) -> str:

--- a/python/layrz_sdk/entities/telemetry/devicemessage.py
+++ b/python/layrz_sdk/entities/telemetry/devicemessage.py
@@ -11,7 +11,6 @@ from layrz_sdk.constants import REJECTED_KEYS, UTC
 from layrz_sdk.entities.device import Device
 from layrz_sdk.entities.message import Message
 from layrz_sdk.entities.position import Position
-from layrz_sdk.helpers import compose_uuid, extract_timestamp_from_uuidv7
 
 
 class DeviceMessage(BaseModel):
@@ -113,6 +112,7 @@ class DeviceMessage(BaseModel):
       if key not in REJECTED_KEYS:
         payload[key] = value
 
+    from layrz_sdk.helpers import compose_uuid
     pk = compose_uuid(ts=received_at, bound='lower')
     return cls(
       id=pk,  # type: ignore
@@ -135,4 +135,5 @@ class DeviceMessage(BaseModel):
 
   @property
   def received_at(self: Self) -> datetime:
+    from layrz_sdk.helpers import extract_timestamp_from_uuidv7
     return extract_timestamp_from_uuidv7(self.pk) if self.pk is not None else datetime.now(UTC)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "layrz-sdk"
-version = "4.3.2"
+version = "4.3.3"
 description = "Layrz SDK for Python"
 authors = [{ name = "Golden M, Inc.", email = "software@goldenm.com" }]
 requires-python = ">=3.13"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "layrz-sdk"
-version = "4.1.13"
+version = "4.3.2"
 description = "Layrz SDK for Python"
 authors = [{ name = "Golden M, Inc.", email = "software@goldenm.com" }]
 requires-python = ">=3.13"


### PR DESCRIPTION
## 📋 Summary

- Add configurable `decimals` field (default=3) to chart series and number chart models
- Apply consistent numeric rounding across all chart renderers
- Export `get_color_list` utility from the top-level SDK package
- Fix lazy-import in `DeviceMessage` to break circular import

## 📝 Changes

### ✨ Features
- `ChartDataSerie`: new `decimals: int` field (default=3) for controlling yAxis rounding precision
- `ScatterSerie`: new `decimals: int` field for x/y value rounding
- `NumberChart`: new `decimals: int` field; value is rounded on render
- `get_color_list` now exported from `layrz_sdk.entities`

### 🐛 Fixes
- `LineChart`: round float yAxis values using `serie.decimals` on render
- `BarChart`, `ColumnChart`: round numeric yAxis values per serie decimals setting
- `PieChart`, `RadialBarChart`: round single serie values across all render technologies (Syncfusion, ApexCharts, CanvasJS)
- `ScatterChart`: round x/y axis values per serie decimals setting
- `DeviceMessage`: lazy-import helpers to fix circular import

### 🔧 Chore / Config
- Bump version `4.1.13` → `4.3.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)