### PR TITLE
fix(helpers): handle None values in LTTB and raise default target to 2000

### DIFF
--- a/python/layrz_sdk/helpers/charts.py
+++ b/python/layrz_sdk/helpers/charts.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
   from layrz_sdk.entities.charts.chart_data_serie import ChartDataSerie
   from layrz_sdk.entities.charts.line_chart import LineChart
 
-DEFAULT_TARGET = 1000
+DEFAULT_TARGET = 2000
 
 _ELIGIBLE_SERIE_TYPES = {ChartDataSerieType.LINE, ChartDataSerieType.AREA, ChartDataSerieType.SCATTER}
 
@@ -114,7 +114,7 @@ def optimize_line_chart(chart: LineChart, width_px: int | None = None, enable_lt
     return chart
 
   xs_float = _to_float_xs(chart.x_axis)
-  ys_float = [float(v) for v in first_eligible.data]
+  ys_float = [float(v) if v is not None else 0.0 for v in first_eligible.data]
 
   selected = _lttb(xs_float, ys_float, target)
 


### PR DESCRIPTION
## 📋 Summary

- `optimize_line_chart` was crashing with `TypeError: float() argument must be a string or a real number, not 'NoneType'` when a chart series contained `None` values (forward-filled gaps)
- Default LTTB target raised from 1000 to 2000 points for better visual fidelity on high-density time series

## 📝 Changes

### 🐛 Fixes

- **`layrz_sdk/helpers/charts.py`** — guard `None` values in `ys_float` list comprehension, treating them as `0.0` for triangle area calculation

### ✨ Features

- **`layrz_sdk/helpers/charts.py`** — raise `DEFAULT_TARGET` from `1000` to `2000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)