### PR TITLE
fix(helpers): forward-fill None values in LTTB ys_float

### DIFF
--- a/python/layrz_sdk/helpers/charts.py
+++ b/python/layrz_sdk/helpers/charts.py
@@ -114,7 +114,12 @@ def optimize_line_chart(chart: LineChart, width_px: int | None = None, enable_lt
     return chart
 
   xs_float = _to_float_xs(chart.x_axis)
-  ys_float = [float(v) if v is not None else 0.0 for v in first_eligible.data]
+  last_y = 0.0
+  ys_float: list[float] = []
+  for v in first_eligible.data:
+    if v is not None:
+      last_y = float(v)
+    ys_float.append(last_y)
 
   selected = _lttb(xs_float, ys_float, target)
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -352,7 +352,7 @@ wheels = [
 
 [[package]]
 name = "layrz-sdk"
-version = "4.1.13"
+version = "4.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "geopy" },


### PR DESCRIPTION
## 📋 Summary

- Previous fix treated `None` series values as `0.0` in the LTTB Y float list, which distorted triangle area calculations by making gaps look like drops to zero
- Replace with forward-fill: each `None` inherits the last known value, so gaps don't skew which points LTTB selects

## 📝 Changes

### 🐛 Fixes

- **`layrz_sdk/helpers/charts.py`** — build `ys_float` with a forward-fill loop instead of `float(v) if v is not None else 0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)