### PR TITLE
fix(entities): align Go/Python type-contract parity for Asset, Device and DeviceMessage

### DIFF
--- a/go/entities/asset.go
+++ b/go/entities/asset.go
@@ -15,7 +15,7 @@ type Asset struct {
 	// Optional KindId representing the type or category of the asset
 	KindId *int64 `json:"kind_id,omitempty"`
 	// OperationMode indicates the current operation mode of the asset
-	OperationMode *enums.AssetOperationMode `json:"operation_mode,omitempty"`
+	OperationMode enums.AssetOperationMode `json:"operation_mode"`
 	// StaticPosition is the fixed position of the asset when in STATIC mode
 	StaticPosition *StaticPosition `json:"static_position,omitempty"`
 	// Points to the primary device associated with the asset

--- a/go/entities/asset_message.go
+++ b/go/entities/asset_message.go
@@ -114,6 +114,6 @@ func AssetMessageFromDeviceMessage(deviceMessage *DeviceMessage, asset *Asset) *
 		GeofencesIds:     make([]int64, 0),
 		DistanceTraveled: 0,
 		ElapsedTime:      zero,
-		ReceivedAt:       deviceMessage.ReceivedAt,
+		ReceivedAt:       types.UnixTime{Time: deviceMessage.ReceivedAt()},
 	}
 }

--- a/go/entities/asset_message_test.go
+++ b/go/entities/asset_message_test.go
@@ -239,14 +239,14 @@ func TestAssetMessageComputeDistanceNilPrevious(t *testing.T) {
 func TestAssetMessageFromDeviceMessage(t *testing.T) {
 	t.Log("Running tests for AssetMessageFromDeviceMessage")
 
+	testId := "019513f0-7c00-7000-8000-000000000001"
 	deviceMsg := &DeviceMessage{
-		Id:         "test-id",
+		Id:         &testId,
 		DeviceId:   1,
 		Ident:      "dev1",
 		ProtocolId: 5,
 		Position:   map[string]any{"latitude": 10.0, "longitude": -66.0},
 		Payload:    map[string]any{"ignition": true},
-		ReceivedAt: types.UnixTime{Time: time.Unix(1770465935, 0)},
 	}
 
 	asset := &Asset{
@@ -281,7 +281,8 @@ func TestAssetMessageFromDeviceMessageNil(t *testing.T) {
 		t.Error("Expected nil for nil DeviceMessage")
 	}
 
-	deviceMsg := &DeviceMessage{Id: "test"}
+	testId2 := "test"
+	deviceMsg := &DeviceMessage{Id: &testId2}
 
 	if AssetMessageFromDeviceMessage(deviceMsg, nil) != nil {
 		t.Error("Expected nil for nil Asset")

--- a/go/entities/asset_test.go
+++ b/go/entities/asset_test.go
@@ -90,7 +90,7 @@ func TestAsset(t *testing.T) {
 		t.Error("Expected KindId 5")
 	}
 
-	if asset.OperationMode == nil || *asset.OperationMode != enums.AssetOperationModeSingle {
+	if asset.OperationMode != enums.AssetOperationModeSingle {
 		t.Error("Expected OperationMode 'SINGLE'")
 	}
 
@@ -201,8 +201,8 @@ func TestAssetWithChildren(t *testing.T) {
 		t.Fatalf("Failed to unmarshal Asset: %v", err)
 	}
 
-	if *asset.OperationMode != enums.AssetOperationModeAssetMultiple {
-		t.Errorf("Expected OperationMode 'ASSETMULTIPLE', got '%s'", *asset.OperationMode)
+	if asset.OperationMode != enums.AssetOperationModeAssetMultiple {
+		t.Errorf("Expected OperationMode 'ASSETMULTIPLE', got '%s'", asset.OperationMode)
 	}
 
 	if len(asset.Children) != 1 {

--- a/go/entities/device.go
+++ b/go/entities/device.go
@@ -10,8 +10,8 @@ type Device struct {
 	Ident string `json:"ident"`
 	// Optional protocol ID associated with the device. Can be nil depending of the context.
 	ProtocolId *int64 `json:"protocol_id,omitempty"`
-	// Optional protocol name associated with the device. Can be nil depending of the context.
-	Protocol *string `json:"protocol,omitempty"`
+	// Protocol name associated with the device.
+	Protocol string `json:"protocol"`
 	// Indicates if the device is the primary device for the asset.
 	IsPrimary bool `json:"is_primary"`
 	// Optional Modbus configuration for the device. Can be nil if not applicable.

--- a/go/entities/device_message.go
+++ b/go/entities/device_message.go
@@ -1,23 +1,42 @@
 package entities
 
 import (
+	"encoding/binary"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/goldenm-software/layrz-sdk/go/v4/types"
+	"github.com/google/uuid"
 )
 
 // DeviceMessage represents a message sent from or to a device.
 type DeviceMessage struct {
-	Id         string         `json:"id"`
+	Id         *string        `json:"id,omitempty"`
 	DeviceId   int64          `json:"device_id"`
 	Ident      string         `json:"ident"`
 	ProtocolId int64          `json:"protocol_id"`
 	Position   map[string]any `json:"position"`
 	Payload    map[string]any `json:"payload"`
-	ReceivedAt types.UnixTime `json:"received_at"`
+}
+
+// ReceivedAt extracts the timestamp embedded in the UUIDv7 Id.
+// Returns current UTC time if Id is nil or not a valid UUIDv7.
+func (a *DeviceMessage) ReceivedAt() time.Time {
+	if a.Id == nil {
+		return time.Now().UTC()
+	}
+	parsed, err := uuid.Parse(*a.Id)
+	if err != nil {
+		return time.Now().UTC()
+	}
+	u := types.Uuid(parsed)
+	ts := u.TimestampFromV7()
+	if ts == nil {
+		return time.Now().UTC()
+	}
+	return *ts
 }
 
 // DatumGis returns the EPSG code for WGS 84
@@ -47,6 +66,20 @@ func (a *DeviceMessage) PointGis() *string {
 
 	point := fmt.Sprintf("POINT(%f %f)", lon, lat)
 	return &point
+}
+
+// uuidV7FromTime builds a UUIDv7 with the given timestamp encoded in the first 48 bits.
+func uuidV7FromTime(t time.Time) uuid.UUID {
+	var u uuid.UUID
+	msec := uint64(t.UnixMilli())
+	// Encode ms timestamp into first 6 bytes
+	binary.BigEndian.PutUint16(u[0:2], uint16(msec>>32))
+	binary.BigEndian.PutUint32(u[2:6], uint32(msec))
+	// Set version 7 in bits 4–7 of byte 6
+	u[6] = (u[6] & 0x0f) | 0x70
+	// Set variant bits (10xx) in byte 8
+	u[8] = (u[8] & 0x3f) | 0x80
+	return u
 }
 
 func DeviceMessageFromMap(data *map[string]any, device *Device) (*DeviceMessage, error) {
@@ -105,12 +138,15 @@ func DeviceMessageFromMap(data *map[string]any, device *Device) (*DeviceMessage,
 		payload[key] = value
 	}
 
+	u := uuidV7FromTime(receivedAt)
+	idStr := u.String()
+
 	return &DeviceMessage{
+		Id:         &idStr,
 		DeviceId:   device.Id,
 		Ident:      device.Ident,
 		ProtocolId: *device.ProtocolId,
 		Position:   position,
 		Payload:    payload,
-		ReceivedAt: types.UnixTime{Time: receivedAt},
 	}, nil
 }

--- a/go/entities/device_message_test.go
+++ b/go/entities/device_message_test.go
@@ -2,7 +2,6 @@ package entities
 
 import (
 	"encoding/json"
-	"math"
 	"strings"
 	"testing"
 )
@@ -35,8 +34,12 @@ func TestDeviceMessage(t *testing.T) {
 		t.Fatalf("Failed to unmarshal DeviceMessage: %v", err)
 	}
 
-	if msg.Id != "019513f0-7c00-7000-8000-000000000001" {
-		t.Errorf("Expected Id '019513f0-7c00-7000-8000-000000000001', got '%s'", msg.Id)
+	if msg.Id == nil || *msg.Id != "019513f0-7c00-7000-8000-000000000001" {
+		id := "<nil>"
+		if msg.Id != nil {
+			id = *msg.Id
+		}
+		t.Errorf("Expected Id '019513f0-7c00-7000-8000-000000000001', got '%s'", id)
 	}
 
 	if msg.DeviceId != 10 {
@@ -59,9 +62,13 @@ func TestDeviceMessage(t *testing.T) {
 		t.Errorf("Expected 4 payload keys, got %d", len(msg.Payload))
 	}
 
-	receivedAtUnix := float64(msg.ReceivedAt.UnixMicro()) / 1e6
-	if math.Abs(receivedAtUnix-1770465935) > 0.001 {
-		t.Errorf("Expected ReceivedAt ~1770465935, got %f", receivedAtUnix)
+	// ReceivedAt is derived from the UUIDv7 id "019513f0-7c00-...", which encodes ~1739796282s
+	receivedAt := msg.ReceivedAt()
+	if receivedAt.IsZero() {
+		t.Error("Expected non-zero ReceivedAt")
+	}
+	if receivedAt.Unix() < 1739796282 || receivedAt.Unix() > 1739796283 {
+		t.Errorf("Expected ReceivedAt ~1739796282, got %d", receivedAt.Unix())
 	}
 }
 
@@ -182,6 +189,20 @@ func TestDeviceMessageFromMap(t *testing.T) {
 	// Payload should contain all keys (including position. prefixed)
 	if _, ok := msg.Payload["ignition"]; !ok {
 		t.Error("Expected 'ignition' key in Payload")
+	}
+
+	// Id should be set (UUIDv7 composed from received_at)
+	if msg.Id == nil {
+		t.Fatal("Expected Id to be non-nil after DeviceMessageFromMap")
+	}
+
+	// ReceivedAt() should recover a timestamp close to the input (ms precision)
+	receivedAt := msg.ReceivedAt()
+	if receivedAt.IsZero() {
+		t.Error("Expected non-zero ReceivedAt")
+	}
+	if receivedAt.Unix() < 1770465934 || receivedAt.Unix() > 1770465936 {
+		t.Errorf("Expected ReceivedAt ~1770465935, got %d", receivedAt.Unix())
 	}
 }
 

--- a/go/entities/device_test.go
+++ b/go/entities/device_test.go
@@ -52,8 +52,8 @@ func TestDevice(t *testing.T) {
 		t.Error("Expected ProtocolId 5")
 	}
 
-	if device.Protocol == nil || *device.Protocol != "teltonika" {
-		t.Error("Expected Protocol 'teltonika'")
+	if device.Protocol != "teltonika" {
+		t.Errorf("Expected Protocol 'teltonika', got '%s'", device.Protocol)
 	}
 
 	if !device.IsPrimary {
@@ -105,8 +105,8 @@ func TestDeviceMinimal(t *testing.T) {
 		t.Error("Expected ProtocolId to be nil")
 	}
 
-	if device.Protocol != nil {
-		t.Error("Expected Protocol to be nil")
+	if device.Protocol != "" {
+		t.Errorf("Expected Protocol to be empty, got '%s'", device.Protocol)
 	}
 
 	if device.Modbus != nil {


### PR DESCRIPTION
## 📋 Summary

- Audited Go vs Python entity contracts for `Asset`, `AssetMessage`, `Device`, and `DeviceMessage`
- Found 3 required/optional mismatches — all fixed on the Go side (Python is source of truth)
- `DeviceMessage.received_at` now derived from the UUIDv7 `id`, matching Python's property approach

## 🐛 Fixes

- **`Asset.OperationMode`**: changed from `*enums.AssetOperationMode` (optional pointer) to `enums.AssetOperationMode` (required value) — matches Python's required `operation_mode` field
- **`Device.Protocol`**: changed from `*string` (optional pointer) to `string` (required value) — matches Python's required `protocol` field
- **`DeviceMessage.Id`**: changed from `string` (required) to `*string,omitempty` (optional) — matches Python's `UUID | None`
- **`DeviceMessage.ReceivedAt`**: removed the explicit `received_at` JSON field; added `ReceivedAt() time.Time` method that derives the timestamp from the UUIDv7 `Id`, mirroring Python's `received_at` property
- **`DeviceMessageFromMap`**: now composes a UUIDv7 from the `received_at` timestamp (manual bit-packing, since `uuid` v1.6.0 has no `NewV7AtTime`) and stores it in `Id`, so `ReceivedAt()` round-trips correctly
- **`AssetMessageFromDeviceMessage`**: updated to call `deviceMessage.ReceivedAt()` method instead of accessing the removed field
- All entity tests updated to reflect the new type contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)