### PR TITLE
fix(go/entities): align Asset serialization and add timestamp fallbacks in DeviceMessageFromMap

### DIFF
--- a/go/entities/device_message.go
+++ b/go/entities/device_message.go
@@ -97,7 +97,13 @@ func DeviceMessageFromMap(data *map[string]any, device *Device) (*DeviceMessage,
 
 	rawTimestamp, ok := (*data)["received_at"]
 	if !ok {
-		return nil, fmt.Errorf("received_at not found in data")
+		if v, ok := (*data)["server.timestamp"]; ok {
+			rawTimestamp = v
+		} else if v, ok := (*data)["timestamp"]; ok {
+			rawTimestamp = v
+		} else {
+			return nil, fmt.Errorf("received_at not found in data")
+		}
 	}
 
 	var timestamp float64


### PR DESCRIPTION
## Summary

- `DeviceMessageFromMap` previously required `received_at` to be present — real ingest payloads use `server.timestamp`. Added fallback chain: `received_at` → `server.timestamp` → `timestamp` → error
- `Asset` struct fields had `omitempty` on slices and pointers, causing them to be omitted from JSON when empty/nil. Removed `omitempty` so slices serialize as `[]` and pointers as `null`, matching the expected downstream JSON shape

## Test plan

- [ ] `go test ./...` passes
- [ ] Deploy `layrz-kafka-devices-service` and confirm no `received_at not found in data` errors on standard payloads
- [ ] Confirm asset fanout JSON contains `sensors`, `custom_fields`, `devices`, `children`, `contacts`, `points`, `static_position` fields even when empty
- [ ] Confirm payloads with none of the timestamp keys still return an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
