### PR TITLE
fix(entities): align AssetMessage and DeviceMessage Go/Python parity (v4.3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 4.3.9
+
+- Fixed `DeviceMessage.Id` JSON tag: removed `omitempty` so null id serializes as `"id": null` matching Python.
+- Fixed `DeviceMessage` and `AssetMessage` nil maps/slices to serialize as `{}`/`[]` instead of `null` (matching Python `default_factory=dict/list`).
+- Fixed `DeviceMessageFromMap` to read `"timestamp"` key for received-at (was incorrectly reading `"received_at"`), with fallback to current time when missing.
+- Added `RejectedKeys` filtering in `DeviceMessageFromMap` — keys like `ident`, `protocol.id`, `device.id`, `server.timestamp` are now excluded from payload, matching Python's `REJECTED_KEYS` constant.
+- Fixed `position.*` values in `DeviceMessageFromMap` to only accept numeric types (matching Python's `isinstance(value, (float, int))` guard).
+- Fixed `AssetMessageFromDeviceMessage` to derive position from `asset.OperationMode`: `DISCONNECTED` → empty, `STATIC` → static position, `ZONE` → centroid of points, default → device position.
+- Fixed `AssetMessageFromDeviceMessage` to prefix all payload keys with `"{ident}."` matching Python's `f'{device_message.ident}.{key}'`.
+- Replaced haversine distance formula with Vincenty inverse on WGS-84 in `AssetMessage.ComputeDistanceTraveled`, matching `geopy.distance.geodesic` output.
+- Added UUIDv7 validation on `DeviceMessage.Id` and `AssetMessage.Id` via custom `UnmarshalJSON`, matching Python's `pk` field validator.
+
 ## 4.3.8
 
 - Fixed `BroadcastPayload.asset` to be required (non-optional) to match Python parity.

--- a/go/entities/asset_message.go
+++ b/go/entities/asset_message.go
@@ -1,10 +1,12 @@
 package entities
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/goldenm-software/layrz-sdk/go/v4/enums"
 	"github.com/goldenm-software/layrz-sdk/go/v4/types"
-	"github.com/umahmood/haversine"
+	"github.com/google/uuid"
 )
 
 // AssetMessage represents a message sent from or to an asset.
@@ -17,18 +19,52 @@ type AssetMessage struct {
 	Position map[string]any `json:"position"`
 	// Payload data from the asset message.
 	Payload map[string]any `json:"payload"`
-	// Sensor data extracted from the payload. Can be an empty map if no sensors are present or it was not processed.
+	// Sensor data extracted from the payload.
 	Sensors map[string]any `json:"sensors"`
-	// IDs of geofences associated with the asset message. Can be an empty slice if none are associated.
+	// IDs of geofences associated with the asset message.
 	GeofencesIds []int64 `json:"geofences_ids"`
-	// Distance traveled since the last message in meters. To be computed externally.
-	// You can compute this using the ComputeDistanceTraveled method.
+	// Distance traveled since the last message in meters.
 	DistanceTraveled float64 `json:"distance_traveled"`
 	// Time when the message was received.
 	ReceivedAt types.UnixTime `json:"received_at"`
-	// Elapsed time since the last message. To be computed externally.
-	// You can compute this using the ComputeElapsedTime method.
+	// Elapsed time since the last message.
 	ElapsedTime types.Duration `json:"elapsed_time"`
+}
+
+// MarshalJSON ensures nil maps/slices serialize as {}/{} rather than null, matching Python defaults.
+func (a AssetMessage) MarshalJSON() ([]byte, error) {
+	type alias AssetMessage
+	a2 := alias(a)
+	if a2.Position == nil {
+		a2.Position = map[string]any{}
+	}
+	if a2.Payload == nil {
+		a2.Payload = map[string]any{}
+	}
+	if a2.Sensors == nil {
+		a2.Sensors = map[string]any{}
+	}
+	if a2.GeofencesIds == nil {
+		a2.GeofencesIds = []int64{}
+	}
+	return json.Marshal(a2)
+}
+
+// UnmarshalJSON validates that Id, if present, is a valid UUIDv7 string.
+func (a *AssetMessage) UnmarshalJSON(data []byte) error {
+	type alias AssetMessage
+	var a2 alias
+	if err := json.Unmarshal(data, &a2); err != nil {
+		return err
+	}
+	if a2.Id != nil {
+		parsed, err := uuid.Parse(*a2.Id)
+		if err != nil || parsed.Version() != 7 {
+			return fmt.Errorf("id must be a valid UUIDv7, got %q", *a2.Id)
+		}
+	}
+	*a = AssetMessage(a2)
+	return nil
 }
 
 // DatumGis returns the EPSG code for WGS 84
@@ -36,16 +72,13 @@ func (a *AssetMessage) DatumGis() int32 {
 	return 4326
 }
 
-// HasPoint checks if the asset message contains valid latitude and longitude in its position
+// HasPoint checks if the asset message contains valid latitude and longitude in its position.
+// Accepts both float64 and integer numeric types.
 func (a *AssetMessage) HasPoint() bool {
 	if a.Position == nil {
 		return false
 	}
-
-	_, latOk := a.Position["latitude"].(float64)
-	_, lonOk := a.Position["longitude"].(float64)
-
-	return latOk && lonOk
+	return toFloat64(a.Position["latitude"]) != nil && toFloat64(a.Position["longitude"]) != nil
 }
 
 // PointGis returns the GIS point representation of the asset message
@@ -54,8 +87,8 @@ func (a *AssetMessage) PointGis() *string {
 		return nil
 	}
 
-	lat := a.Position["latitude"].(float64)
-	lon := a.Position["longitude"].(float64)
+	lat := *toFloat64(a.Position["latitude"])
+	lon := *toFloat64(a.Position["longitude"])
 
 	point := fmt.Sprintf("POINT(%f %f)", lon, lat)
 	return &point
@@ -77,25 +110,25 @@ func (a *AssetMessage) ComputeElapsedTime(previousMessage *AssetMessage) *types.
 	return &duration
 }
 
-// ComputeDistanceTraveled calculates the distance traveled between this message and a previous message
+// ComputeDistanceTraveled calculates the distance in meters between this message and a previous one.
+// Uses the Vincenty inverse formula on WGS-84, matching geopy.distance.geodesic (Python).
 func (a *AssetMessage) ComputeDistanceTraveled(previousMessage *AssetMessage) float64 {
 	if previousMessage == nil || !a.HasPoint() || !previousMessage.HasPoint() {
 		return 0
 	}
 
-	lat1 := a.Position["latitude"].(float64)
-	lon1 := a.Position["longitude"].(float64)
-	lat2 := previousMessage.Position["latitude"].(float64)
-	lon2 := previousMessage.Position["longitude"].(float64)
+	lat1 := *toFloat64(a.Position["latitude"])
+	lon1 := *toFloat64(a.Position["longitude"])
+	lat2 := *toFloat64(previousMessage.Position["latitude"])
+	lon2 := *toFloat64(previousMessage.Position["longitude"])
 
-	msg1 := haversine.Coord{Lat: lat1, Lon: lon1}
-	msg2 := haversine.Coord{Lat: lat2, Lon: lon2}
-
-	_, distance := haversine.Distance(msg1, msg2)
-	return distance * 1000 // The haversine package returns distance in kilometers, convert to meters
+	return geodesicDistance(lat1, lon1, lat2, lon2)
 }
 
-// Helper function to create an AssetMessage from a DeviceMessage
+// AssetMessageFromDeviceMessage constructs an AssetMessage from a DeviceMessage and Asset.
+// Mirrors Python's AssetMessage.parse_from_devicemessage:
+//   - position is derived from asset.operation_mode
+//   - payload keys are prefixed with "{ident}."
 func AssetMessageFromDeviceMessage(deviceMessage *DeviceMessage, asset *Asset) *AssetMessage {
 	zero := types.Duration(0)
 	if deviceMessage == nil {
@@ -106,10 +139,55 @@ func AssetMessageFromDeviceMessage(deviceMessage *DeviceMessage, asset *Asset) *
 		return nil
 	}
 
+	var position map[string]any
+	switch asset.OperationMode {
+	case enums.AssetOperationModeDisconnected:
+		position = map[string]any{}
+	case enums.AssetOperationModeStatic:
+		if asset.StaticPosition != nil {
+			position = map[string]any{
+				"latitude":  asset.StaticPosition.Latitude,
+				"longitude": asset.StaticPosition.Longitude,
+			}
+			if asset.StaticPosition.Altitude != nil {
+				position["altitude"] = *asset.StaticPosition.Altitude
+			}
+		} else {
+			position = map[string]any{}
+		}
+	case enums.AssetOperationModeZone:
+		if len(asset.Points) > 0 {
+			var sumLat, sumLon float64
+			for _, p := range asset.Points {
+				sumLat += p.Latitude
+				sumLon += p.Longitude
+			}
+			n := float64(len(asset.Points))
+			position = map[string]any{
+				"latitude":  sumLat / n,
+				"longitude": sumLon / n,
+			}
+		} else {
+			position = map[string]any{}
+		}
+	default:
+		// SINGLE, MULTIPLE, ASSETMULTIPLE — use device position
+		if deviceMessage.Position != nil {
+			position = deviceMessage.Position
+		} else {
+			position = map[string]any{}
+		}
+	}
+
+	payload := make(map[string]any, len(deviceMessage.Payload))
+	for key, value := range deviceMessage.Payload {
+		payload[deviceMessage.Ident+"."+key] = value
+	}
+
 	return &AssetMessage{
 		AssetId:          asset.Id,
-		Position:         deviceMessage.Position,
-		Payload:          deviceMessage.Payload,
+		Position:         position,
+		Payload:          payload,
 		Sensors:          make(map[string]any),
 		GeofencesIds:     make([]int64, 0),
 		DistanceTraveled: 0,

--- a/go/entities/asset_message_test.go
+++ b/go/entities/asset_message_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goldenm-software/layrz-sdk/go/v4/enums"
 	"github.com/goldenm-software/layrz-sdk/go/v4/types"
 )
 
@@ -270,6 +271,14 @@ func TestAssetMessageFromDeviceMessage(t *testing.T) {
 	if assetMsg.DistanceTraveled != 0 {
 		t.Error("Expected DistanceTraveled to be 0")
 	}
+
+	// Payload keys must be prefixed with ident
+	if _, ok := assetMsg.Payload["dev1.ignition"]; !ok {
+		t.Error("Expected 'dev1.ignition' key in Payload (ident prefix)")
+	}
+	if _, ok := assetMsg.Payload["ignition"]; ok {
+		t.Error("Did not expect unprefixed 'ignition' key in Payload")
+	}
 }
 
 func TestAssetMessageFromDeviceMessageNil(t *testing.T) {
@@ -282,9 +291,167 @@ func TestAssetMessageFromDeviceMessageNil(t *testing.T) {
 	}
 
 	testId2 := "test"
-	deviceMsg := &DeviceMessage{Id: &testId2}
+	deviceMsg2 := &DeviceMessage{Id: &testId2}
 
-	if AssetMessageFromDeviceMessage(deviceMsg, nil) != nil {
+	if AssetMessageFromDeviceMessage(deviceMsg2, nil) != nil {
 		t.Error("Expected nil for nil Asset")
+	}
+}
+
+func TestAssetMessageFromDeviceMessageOperationModes(t *testing.T) {
+	t.Log("Running tests for AssetMessageFromDeviceMessage operation mode position derivation")
+
+	testId := "019513f0-7c00-7000-8000-000000000001"
+	deviceMsg := &DeviceMessage{
+		Id:       &testId,
+		Ident:    "dev1",
+		Position: map[string]any{"latitude": 10.0, "longitude": -66.0},
+		Payload:  map[string]any{},
+	}
+
+	altitude := 100.0
+
+	tests := []struct {
+		name        string
+		asset       *Asset
+		expectLat   *float64
+		expectLon   *float64
+		expectEmpty bool
+	}{
+		{
+			name:        "DISCONNECTED gives empty position",
+			asset:       &Asset{Id: 1, OperationMode: enums.AssetOperationModeDisconnected},
+			expectEmpty: true,
+		},
+		{
+			name: "STATIC gives static position",
+			asset: &Asset{
+				Id:             1,
+				OperationMode:  enums.AssetOperationModeStatic,
+				StaticPosition: &StaticPosition{Latitude: 5.0, Longitude: -70.0, Altitude: &altitude},
+			},
+			expectLat: floatPtr(5.0),
+			expectLon: floatPtr(-70.0),
+		},
+		{
+			name: "STATIC with nil StaticPosition gives empty",
+			asset: &Asset{
+				Id:            1,
+				OperationMode: enums.AssetOperationModeStatic,
+			},
+			expectEmpty: true,
+		},
+		{
+			name: "ZONE computes centroid",
+			asset: &Asset{
+				Id:            1,
+				OperationMode: enums.AssetOperationModeZone,
+				Points: []StaticPosition{
+					{Latitude: 10.0, Longitude: -66.0},
+					{Latitude: 12.0, Longitude: -68.0},
+				},
+			},
+			expectLat: floatPtr(11.0),
+			expectLon: floatPtr(-67.0),
+		},
+		{
+			name: "ZONE with no points gives empty",
+			asset: &Asset{
+				Id:            1,
+				OperationMode: enums.AssetOperationModeZone,
+			},
+			expectEmpty: true,
+		},
+		{
+			name:      "SINGLE uses device position",
+			asset:     &Asset{Id: 1, OperationMode: enums.AssetOperationModeSingle},
+			expectLat: floatPtr(10.0),
+			expectLon: floatPtr(-66.0),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := AssetMessageFromDeviceMessage(deviceMsg, tc.asset)
+			if msg == nil {
+				t.Fatal("Expected non-nil AssetMessage")
+			}
+			if tc.expectEmpty {
+				if len(msg.Position) != 0 {
+					t.Errorf("Expected empty position, got %v", msg.Position)
+				}
+				return
+			}
+			lat := toFloat64(msg.Position["latitude"])
+			lon := toFloat64(msg.Position["longitude"])
+			if lat == nil || math.Abs(*lat-*tc.expectLat) > 1e-9 {
+				t.Errorf("Expected latitude %v, got %v", tc.expectLat, lat)
+			}
+			if lon == nil || math.Abs(*lon-*tc.expectLon) > 1e-9 {
+				t.Errorf("Expected longitude %v, got %v", tc.expectLon, lon)
+			}
+		})
+	}
+}
+
+func floatPtr(f float64) *float64 { return &f }
+
+func TestAssetMessageNilMapMarshal(t *testing.T) {
+	t.Log("Nil maps/slices must serialize as {}/{} not null")
+
+	msg := AssetMessage{AssetId: 1}
+	data, err := json.Marshal(&msg)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	s := string(data)
+	for _, want := range []string{`"position":{}`, `"payload":{}`, `"sensors":{}`, `"geofences_ids":[]`} {
+		if !strings.Contains(s, want) {
+			t.Errorf("Expected %s in JSON, got: %s", want, s)
+		}
+	}
+}
+
+func TestAssetMessageInvalidUUID(t *testing.T) {
+	t.Log("UnmarshalJSON must reject non-UUIDv7 id")
+
+	jsonData := `{"id": "not-a-uuid", "asset_id": 1, "position": {}, "payload": {}, "sensors": {}, "geofences_ids": [], "distance_traveled": 0, "received_at": 1770465935, "elapsed_time": 0}`
+	var msg AssetMessage
+	if err := json.Unmarshal([]byte(jsonData), &msg); err == nil {
+		t.Error("Expected error for invalid UUIDv7 id")
+	}
+}
+
+func TestAssetMessageGeodesicDistance(t *testing.T) {
+	t.Log("ComputeDistanceTraveled must match geopy.distance.geodesic reference values")
+
+	type testCase struct {
+		label                  string
+		lat1, lon1, lat2, lon2 float64
+		want                   float64
+		tol                    float64
+	}
+
+	tests := []testCase{
+		{"Caracas small", 10.4806, -66.9036, 10.4900, -66.9100, 1253.771872, 0.01},
+		{"equator 1deg", 0.0, 0.0, 0.0, 1.0, 111319.490793, 0.01},
+		{"NYC to London", 40.7128, -74.0060, 51.5074, -0.1278, 5585233.578931, 1.0},
+		{"pole to pole", 90.0, 0.0, -90.0, 0.0, 20003931.458625, 1.0},
+		{"same point", 10.4806, -66.9036, 10.4806, -66.9036, 0.0, 1e-6},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.label, func(t *testing.T) {
+			current := &AssetMessage{
+				Position: map[string]any{"latitude": tc.lat1, "longitude": tc.lon1},
+			}
+			previous := &AssetMessage{
+				Position: map[string]any{"latitude": tc.lat2, "longitude": tc.lon2},
+			}
+			got := current.ComputeDistanceTraveled(previous)
+			if math.Abs(got-tc.want) > tc.tol {
+				t.Errorf("%s: want %.6f m, got %.6f m (diff %.6f > tol %.6f)", tc.label, tc.want, got, math.Abs(got-tc.want), tc.tol)
+			}
+		})
 	}
 }

--- a/go/entities/constants.go
+++ b/go/entities/constants.go
@@ -1,0 +1,14 @@
+package entities
+
+// RejectedKeys mirrors Python's layrz_sdk.constants.REJECTED_KEYS.
+// These raw telemetry keys are not copied into the DeviceMessage payload.
+var RejectedKeys = map[string]struct{}{
+	"timestamp":        {},
+	"ident":            {},
+	"server.timestamp": {},
+	"protocol.id":      {},
+	"channel.id":       {},
+	"device.name":      {},
+	"device.id":        {},
+	"device.type.id":   {},
+}

--- a/go/entities/device_message.go
+++ b/go/entities/device_message.go
@@ -2,6 +2,7 @@ package entities
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -13,12 +14,42 @@ import (
 
 // DeviceMessage represents a message sent from or to a device.
 type DeviceMessage struct {
-	Id         *string        `json:"id,omitempty"`
+	Id         *string        `json:"id"`
 	DeviceId   int64          `json:"device_id"`
 	Ident      string         `json:"ident"`
 	ProtocolId int64          `json:"protocol_id"`
 	Position   map[string]any `json:"position"`
 	Payload    map[string]any `json:"payload"`
+}
+
+// MarshalJSON ensures nil maps serialize as {} rather than null, matching Python defaults.
+func (d DeviceMessage) MarshalJSON() ([]byte, error) {
+	type alias DeviceMessage
+	a := alias(d)
+	if a.Position == nil {
+		a.Position = map[string]any{}
+	}
+	if a.Payload == nil {
+		a.Payload = map[string]any{}
+	}
+	return json.Marshal(a)
+}
+
+// UnmarshalJSON validates that Id, if present, is a valid UUIDv7 string.
+func (d *DeviceMessage) UnmarshalJSON(data []byte) error {
+	type alias DeviceMessage
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	if a.Id != nil {
+		parsed, err := uuid.Parse(*a.Id)
+		if err != nil || parsed.Version() != 7 {
+			return fmt.Errorf("id must be a valid UUIDv7, got %q", *a.Id)
+		}
+	}
+	*d = DeviceMessage(a)
+	return nil
 }
 
 // ReceivedAt extracts the timestamp embedded in the UUIDv7 Id.
@@ -44,28 +75,47 @@ func (a *DeviceMessage) DatumGis() int32 {
 	return 4326
 }
 
+// HasPoint checks if the device message contains valid latitude and longitude in its position.
+// Accepts both float64 and integer numeric types.
 func (a *DeviceMessage) HasPoint() bool {
 	if a.Position == nil {
 		return false
 	}
-
-	_, latOk := a.Position["latitude"].(float64)
-	_, lonOk := a.Position["longitude"].(float64)
-
-	return latOk && lonOk
+	return toFloat64(a.Position["latitude"]) != nil && toFloat64(a.Position["longitude"]) != nil
 }
 
-// PointGis returns the GIS point representation of the asset message
+// PointGis returns the GIS point representation of the device message
 func (a *DeviceMessage) PointGis() *string {
 	if !a.HasPoint() {
 		return nil
 	}
 
-	lat := a.Position["latitude"].(float64)
-	lon := a.Position["longitude"].(float64)
+	lat := *toFloat64(a.Position["latitude"])
+	lon := *toFloat64(a.Position["longitude"])
 
 	point := fmt.Sprintf("POINT(%f %f)", lon, lat)
 	return &point
+}
+
+// toFloat64 converts common numeric JSON-unmarshaled types to *float64.
+func toFloat64(v any) *float64 {
+	switch n := v.(type) {
+	case float64:
+		return &n
+	case float32:
+		f := float64(n)
+		return &f
+	case int:
+		f := float64(n)
+		return &f
+	case int32:
+		f := float64(n)
+		return &f
+	case int64:
+		f := float64(n)
+		return &f
+	}
+	return nil
 }
 
 // uuidV7FromTime builds a UUIDv7 with the given timestamp encoded in the first 48 bits.
@@ -82,6 +132,11 @@ func uuidV7FromTime(t time.Time) uuid.UUID {
 	return u
 }
 
+// DeviceMessageFromMap constructs a DeviceMessage from a raw telemetry map and a Device.
+// Mirrors Python's DeviceMessage.parse_from_dict:
+//   - reads "timestamp" key (Unix seconds) for received_at; falls back to now
+//   - position.* keys populate position (stripped, numeric only) and payload (raw)
+//   - keys in RejectedKeys are excluded from payload
 func DeviceMessageFromMap(data *map[string]any, device *Device) (*DeviceMessage, error) {
 	if data == nil {
 		return nil, fmt.Errorf("data is nil")
@@ -95,47 +150,54 @@ func DeviceMessageFromMap(data *map[string]any, device *Device) (*DeviceMessage,
 		return nil, fmt.Errorf("device protocol ID is nil")
 	}
 
-	rawTimestamp, ok := (*data)["received_at"]
-	if !ok {
-		return nil, fmt.Errorf("received_at not found in data")
-	}
-
-	var timestamp float64
-	switch v := rawTimestamp.(type) {
-	case float64:
-		timestamp = v
-	case float32:
-		timestamp = float64(v)
-	case int64:
-		timestamp = float64(v)
-	case int32:
-		timestamp = float64(v)
-	case int:
-		timestamp = float64(v)
-	case string:
-		parsed, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid string format for received_at: %v", err)
+	var receivedAt time.Time
+	if rawTimestamp, ok := (*data)["timestamp"]; ok {
+		var timestamp float64
+		switch v := rawTimestamp.(type) {
+		case float64:
+			timestamp = v
+		case float32:
+			timestamp = float64(v)
+		case int64:
+			timestamp = float64(v)
+		case int32:
+			timestamp = float64(v)
+		case int:
+			timestamp = float64(v)
+		case string:
+			parsed, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid string format for timestamp: %v", err)
+			}
+			timestamp = parsed
+		default:
+			return nil, fmt.Errorf("invalid type for timestamp: %T", rawTimestamp)
 		}
-		timestamp = parsed
-	default:
-		return nil, fmt.Errorf("invalid type for received_at: %T", rawTimestamp)
+		msec := int64(timestamp * types.MicrosecondsToSeconds)
+		receivedAt = time.UnixMicro(msec).UTC()
+	} else {
+		receivedAt = time.Now().UTC()
 	}
-
-	msec := int64(timestamp * types.MicrosecondsToSeconds)
-	receivedAt := time.UnixMicro(msec).UTC()
 
 	position := make(map[string]any)
 	payload := make(map[string]any)
 
 	for key, value := range *data {
 		if posKey, ok := strings.CutPrefix(key, "position."); ok {
-			position[posKey] = value
-			payload[key] = value
+			// Only numeric values go into position (mirrors Python's isinstance(value, (float, int)))
+			if f := toFloat64(value); f != nil {
+				position[posKey] = *f
+			}
+			// Raw position.* key also goes into payload unless rejected
+			if _, rejected := RejectedKeys[key]; !rejected {
+				payload[key] = value
+			}
 			continue
 		}
 
-		payload[key] = value
+		if _, rejected := RejectedKeys[key]; !rejected {
+			payload[key] = value
+		}
 	}
 
 	u := uuidV7FromTime(receivedAt)

--- a/go/entities/device_message_test.go
+++ b/go/entities/device_message_test.go
@@ -75,7 +75,7 @@ func TestDeviceMessage(t *testing.T) {
 func TestDeviceMessageMethods(t *testing.T) {
 	t.Log("Running tests for DeviceMessage methods")
 	jsonData := `{
-		"id": "test-id",
+		"id": "019513f0-7c00-7000-8000-000000000001",
 		"device_id": 1,
 		"ident": "dev1",
 		"protocol_id": 1,
@@ -83,8 +83,7 @@ func TestDeviceMessageMethods(t *testing.T) {
 			"latitude": 10.4806,
 			"longitude": -66.9036
 		},
-		"payload": {},
-		"received_at": 1770465935
+		"payload": {}
 	}`
 
 	var msg DeviceMessage
@@ -117,13 +116,12 @@ func TestDeviceMessageMethods(t *testing.T) {
 func TestDeviceMessageNoPosition(t *testing.T) {
 	t.Log("Running tests for DeviceMessage without valid position")
 	jsonData := `{
-		"id": "test-id",
+		"id": "019513f0-7c00-7000-8000-000000000001",
 		"device_id": 1,
 		"ident": "dev1",
 		"protocol_id": 1,
 		"position": {},
-		"payload": {},
-		"received_at": 1770465935
+		"payload": {}
 	}`
 
 	var msg DeviceMessage
@@ -157,7 +155,7 @@ func TestDeviceMessageFromMap(t *testing.T) {
 		"position.longitude": -66.9036,
 		"position.speed":     55.0,
 		"ignition":           true,
-		"received_at":        1770465935.0,
+		"timestamp":          1770465935.0,
 	}
 
 	msg, err := DeviceMessageFromMap(&data, device)
@@ -223,10 +221,120 @@ func TestDeviceMessageFromMapNilData(t *testing.T) {
 
 func TestDeviceMessageFromMapNilDevice(t *testing.T) {
 	t.Log("Running tests for DeviceMessageFromMap with nil device")
-	data := map[string]any{"received_at": 1770465935.0}
+	data := map[string]any{"timestamp": 1770465935.0}
 
 	_, err := DeviceMessageFromMap(&data, nil)
 	if err == nil {
 		t.Error("Expected error for nil device")
+	}
+}
+
+func TestDeviceMessageFromMapRejectedKeys(t *testing.T) {
+	t.Log("RejectedKeys must not appear in payload")
+
+	protocolId := int64(5)
+	device := &Device{
+		Id:         1,
+		Ident:      "dev1",
+		ProtocolId: &protocolId,
+	}
+
+	data := map[string]any{
+		"timestamp":        1770465935.0,
+		"ident":            "dev1",    // rejected
+		"protocol.id":      5,         // rejected
+		"device.id":        1,         // rejected
+		"server.timestamp": 1234567.0, // rejected
+		"ignition":         true,      // not rejected
+		"fuel_level":       75.5,      // not rejected
+	}
+
+	msg, err := DeviceMessageFromMap(&data, device)
+	if err != nil {
+		t.Fatalf("DeviceMessageFromMap failed: %v", err)
+	}
+
+	for key := range RejectedKeys {
+		if _, ok := msg.Payload[key]; ok {
+			t.Errorf("Expected rejected key %q to not be in payload", key)
+		}
+	}
+
+	if _, ok := msg.Payload["ignition"]; !ok {
+		t.Error("Expected 'ignition' in payload")
+	}
+	if _, ok := msg.Payload["fuel_level"]; !ok {
+		t.Error("Expected 'fuel_level' in payload")
+	}
+}
+
+func TestDeviceMessageFromMapFallbackTimestamp(t *testing.T) {
+	t.Log("DeviceMessageFromMap must fall back to now when timestamp key is missing")
+
+	protocolId := int64(5)
+	device := &Device{Id: 1, Ident: "dev1", ProtocolId: &protocolId}
+	data := map[string]any{"ignition": true}
+
+	msg, err := DeviceMessageFromMap(&data, device)
+	if err != nil {
+		t.Fatalf("Expected no error with missing timestamp, got: %v", err)
+	}
+	if msg.Id == nil {
+		t.Error("Expected Id to be set")
+	}
+}
+
+func TestDeviceMessageNilMapMarshal(t *testing.T) {
+	t.Log("Nil maps must serialize as {} not null")
+
+	msg := DeviceMessage{DeviceId: 1, Ident: "dev1"}
+	data, err := json.Marshal(&msg)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	s := string(data)
+	for _, want := range []string{`"position":{}`, `"payload":{}`, `"id":null`} {
+		if !strings.Contains(s, want) {
+			t.Errorf("Expected %s in JSON, got: %s", want, s)
+		}
+	}
+}
+
+func TestDeviceMessageInvalidUUID(t *testing.T) {
+	t.Log("UnmarshalJSON must reject non-UUIDv7 id")
+
+	jsonData := `{"id": "not-a-uuid", "device_id": 1, "ident": "dev1", "protocol_id": 1, "position": {}, "payload": {}}`
+	var msg DeviceMessage
+	if err := json.Unmarshal([]byte(jsonData), &msg); err == nil {
+		t.Error("Expected error for invalid UUIDv7 id")
+	}
+}
+
+func TestDeviceMessagePositionNumericGuard(t *testing.T) {
+	t.Log("Non-numeric position.* values must not be inserted into position")
+
+	protocolId := int64(5)
+	device := &Device{Id: 1, Ident: "dev1", ProtocolId: &protocolId}
+	data := map[string]any{
+		"timestamp":          1770465935.0,
+		"position.latitude":  10.5,
+		"position.longitude": -66.9,
+		"position.label":     "home", // string — must not go into position
+		"position.active":    true,   // bool — must not go into position
+	}
+
+	msg, err := DeviceMessageFromMap(&data, device)
+	if err != nil {
+		t.Fatalf("DeviceMessageFromMap failed: %v", err)
+	}
+
+	if _, ok := msg.Position["label"]; ok {
+		t.Error("String value 'label' must not be in position")
+	}
+	if _, ok := msg.Position["active"]; ok {
+		t.Error("Bool value 'active' must not be in position")
+	}
+	if _, ok := msg.Position["latitude"]; !ok {
+		t.Error("Expected 'latitude' in position")
 	}
 }

--- a/go/entities/geodesic.go
+++ b/go/entities/geodesic.go
@@ -1,0 +1,74 @@
+package entities
+
+import "math"
+
+// geodesicDistance returns the geodesic distance in meters between two points on the
+// WGS-84 ellipsoid using the Vincenty inverse formula.
+// This matches geopy.distance.geodesic (Python) for the same inputs.
+// Returns 0 for identical points or antipodal pairs that fail to converge.
+func geodesicDistance(lat1, lon1, lat2, lon2 float64) float64 {
+	// WGS-84 ellipsoid parameters (matches geopy defaults)
+	const (
+		a = 6378137.0           // semi-major axis (meters)
+		f = 1.0 / 298.257223563 // flattening
+		b = a * (1 - f)         // semi-minor axis
+	)
+
+	φ1 := lat1 * math.Pi / 180
+	φ2 := lat2 * math.Pi / 180
+	λ1 := lon1 * math.Pi / 180
+	λ2 := lon2 * math.Pi / 180
+
+	U1 := math.Atan((1 - f) * math.Tan(φ1))
+	U2 := math.Atan((1 - f) * math.Tan(φ2))
+
+	sinU1 := math.Sin(U1)
+	cosU1 := math.Cos(U1)
+	sinU2 := math.Sin(U2)
+	cosU2 := math.Cos(U2)
+
+	λ := λ2 - λ1
+	λPrev := 0.0
+	var sinσ, cosσ, σ, sinα, cos2σm, C float64
+	cos2α := 0.0
+
+	const maxIter = 200
+	const eps = 1e-12
+
+	for i := 0; i < maxIter; i++ {
+		sinλ := math.Sin(λ)
+		cosλ := math.Cos(λ)
+
+		term1 := cosU2 * sinλ
+		term2 := cosU1*sinU2 - sinU1*cosU2*cosλ
+		sinσ = math.Sqrt(term1*term1 + term2*term2)
+
+		if sinσ == 0 {
+			return 0 // coincident points
+		}
+
+		cosσ = sinU1*sinU2 + cosU1*cosU2*cosλ
+		σ = math.Atan2(sinσ, cosσ)
+		sinα = cosU1 * cosU2 * sinλ / sinσ
+		cos2α = 1 - sinα*sinα
+		cos2σm = 0.0
+		if cos2α != 0 {
+			cos2σm = cosσ - 2*sinU1*sinU2/cos2α
+		}
+
+		C = f / 16 * cos2α * (4 + f*(4-3*cos2α))
+		λPrev = λ
+		λ = (λ2 - λ1) + (1-C)*f*sinα*(σ+C*sinσ*(cos2σm+C*cosσ*(-1+2*cos2σm*cos2σm)))
+
+		if math.Abs(λ-λPrev) <= eps {
+			break
+		}
+	}
+
+	u2 := cos2α * (a*a - b*b) / (b * b)
+	A := 1 + u2/16384*(4096+u2*(-768+u2*(320-175*u2)))
+	B := u2 / 1024 * (256 + u2*(-128+u2*(74-47*u2)))
+	Δσ := B * sinσ * (cos2σm + B/4*(cosσ*(-1+2*cos2σm*cos2σm)-B/6*cos2σm*(-3+4*sinσ*sinσ)*(-3+4*cos2σm*cos2σm)))
+
+	return b * A * (σ - Δσ)
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -2,6 +2,4 @@ module github.com/goldenm-software/layrz-sdk/go/v4
 
 go 1.25.5
 
-require github.com/umahmood/haversine v0.0.0-20151105152445-808ab04add26
-
 require github.com/google/uuid v1.6.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,4 +1,2 @@
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/umahmood/haversine v0.0.0-20151105152445-808ab04add26 h1:UFHFmFfixpmfRBcxuu+LA9l8MdURWVdVNUHxO5n1d2w=
-github.com/umahmood/haversine v0.0.0-20151105152445-808ab04add26/go.mod h1:IGhd0qMDsUa9acVjsbsT7bu3ktadtGOHI79+idTew/M=

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -352,7 +352,7 @@ wheels = [
 
 [[package]]
 name = "layrz-sdk"
-version = "4.3.3"
+version = "4.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "geopy" },


### PR DESCRIPTION
## 📋 Summary

- Fixes 11 Go/Python contract mismatches in `AssetMessage` and `DeviceMessage` so both SDKs produce and consume identical JSON.
- Python remains the source of truth throughout.
- Bumps version to `4.3.9`.

## 🐛 Fixes

### DeviceMessage (Go)
- **`id` omitempty removed** — null id now serializes as `"id": null` matching Python's `serialize_by_alias=True` behavior.
- **Nil map normalization** — `position` and `payload` now serialize as `{}` instead of `null` via custom `MarshalJSON`.
- **Timestamp key mismatch** — `DeviceMessageFromMap` now reads `"timestamp"` (was incorrectly reading `"received_at"`); falls back to current time when missing.
- **`RejectedKeys` filtering** — keys like `ident`, `protocol.id`, `device.id`, `server.timestamp` are now excluded from payload, mirroring Python's `REJECTED_KEYS` constant.
- **Numeric guard on `position.*`** — non-numeric values (strings, bools) are no longer inserted into position, matching Python's `isinstance(value, (float, int))` check.
- **UUIDv7 validation** — custom `UnmarshalJSON` rejects non-UUIDv7 `id` strings, matching Python's `pk` field validator.

### AssetMessage (Go)
- **Nil map/slice normalization** — `position`, `payload`, `sensors` serialize as `{}` and `geofences_ids` as `[]` instead of `null`.
- **UUIDv7 validation** — same as DeviceMessage.
- **`operation_mode` branching in `AssetMessageFromDeviceMessage`** — position is now derived from `asset.OperationMode`: `DISCONNECTED` → `{}`, `STATIC` → static position, `ZONE` → centroid of points, default → device position.
- **Payload key prefixing** — all payload keys are now prefixed with `"{ident}."`, matching Python's `f'{device_message.ident}.{key}'`.
- **Geodesic distance** — haversine replaced with Vincenty inverse on WGS-84, matching `geopy.distance.geodesic` output (verified with pinned reference values).

## 🔧 Chore / Config

- Removed `github.com/umahmood/haversine` dependency from `go.mod`.
- Added `go/entities/constants.go` with `RejectedKeys` map.
- Added `go/entities/geodesic.go` with Vincenty inverse implementation.
- Synced `python/uv.lock` to current version.
- Updated `CHANGELOG.md` for v4.3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)