### PR TITLE
fix(types): accept string-encoded timestamps in UnixTime (v4.3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.10
+
+- Fixed `types.UnixTime` JSON unmarshaling to accept string-encoded timestamps (e.g. `"1746518400.123"`) in addition to bare numbers, preventing message drops in Go consumers when producers emit quoted floats.
+
 ## 4.3.9
 
 - Fixed `DeviceMessage.Id` JSON tag: removed `omitempty` so null id serializes as `"id": null` matching Python.

--- a/go/types/unix.go
+++ b/go/types/unix.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 )
 
@@ -24,15 +25,22 @@ func (u UnixTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(float64(u.UnixMicro()) / MicrosecondsToSeconds)
 }
 
-// UnmarshalJSON parses a JSON number representing seconds since epoch into a UnixTime
-// It multiplies the seconds by 1e9 to convert to nanoseconds for time.Unix
+// UnmarshalJSON parses a JSON number or string representing seconds since epoch into a UnixTime.
+// Accepts both numeric (1234567890.123) and string ("1234567890.123") forms for cross-language compatibility.
 func (u *UnixTime) UnmarshalJSON(data []byte) error {
 	var seconds float64
 	if err := json.Unmarshal(data, &seconds); err != nil {
-		return err
+		var s string
+		if err2 := json.Unmarshal(data, &s); err2 != nil {
+			return err
+		}
+		f, err3 := strconv.ParseFloat(s, 64)
+		if err3 != nil {
+			return err3
+		}
+		seconds = f
 	}
 
-	msec := int64(seconds * MicrosecondsToSeconds)
-	u.Time = time.UnixMicro(msec)
+	u.Time = time.UnixMicro(int64(seconds * MicrosecondsToSeconds))
 	return nil
 }

--- a/go/types/unix_test.go
+++ b/go/types/unix_test.go
@@ -39,6 +39,23 @@ func TestUnixTime(t *testing.T) {
 	}
 }
 
+func TestUnixTimeString(t *testing.T) {
+	t.Log("Running tests for UnixTime with string input")
+
+	jsonData := `"1770465935.123"`
+
+	var ut UnixTime
+	err := json.Unmarshal([]byte(jsonData), &ut)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal UnixTime from string: %v", err)
+	}
+
+	gotSeconds := float64(ut.UnixMicro()) / 1e6
+	if math.Abs(gotSeconds-1770465935.123) > 0.001 {
+		t.Errorf("Expected ~1770465935.123, got %f", gotSeconds)
+	}
+}
+
 func TestUnixTimeInteger(t *testing.T) {
 	t.Log("Running tests for UnixTime with integer input")
 


### PR DESCRIPTION
## Summary

- Fixed `types.UnixTime.UnmarshalJSON` to accept timestamps encoded as JSON strings (e.g. `"1746518400.123"`) in addition to bare numbers
- Added `TestUnixTimeString` test case covering the string input path
- Bumped version to `4.3.10` and updated `CHANGELOG.md`

## Motivation

Go consumers of `RawBroadcastResult` (and any other entity using `types.UnixTime`) were silently dropping Kafka messages when a producer emitted the `at` field as a quoted float string. The kafka consumer kit logs `decode failed ... skipping` and moves on, causing data loss.

## Test plan

- [ ] `go test ./types/... -v` passes all three `TestUnixTime*` cases (number, string, integer)
- [ ] No existing consumers broken — string is a new accepted form, number still works
- [ ] Deploy to staging and verify no more `decode failed` errors in `outbound.broadcasts.results.v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)