### PR TITLE
fix(types): handle ISO 8601 string timestamps in UnixTime (v4.3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.11
+
+- Fixed `types.UnixTime` JSON unmarshaling to also accept ISO 8601 datetime strings (e.g. `"2026-05-06T03:24:51.099415Z"`); `MarshalJSON` always emits a float regardless of input format.
+
 ## 4.3.10
 
 - Fixed `types.UnixTime` JSON unmarshaling to accept string-encoded timestamps (e.g. `"1746518400.123"`) in addition to bare numbers, preventing message drops in Go consumers when producers emit quoted floats.

--- a/go/types/unix.go
+++ b/go/types/unix.go
@@ -25,8 +25,9 @@ func (u UnixTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(float64(u.UnixMicro()) / MicrosecondsToSeconds)
 }
 
-// UnmarshalJSON parses a JSON number or string representing seconds since epoch into a UnixTime.
-// Accepts both numeric (1234567890.123) and string ("1234567890.123") forms for cross-language compatibility.
+// UnmarshalJSON parses a JSON number or string into a UnixTime.
+// Accepts: bare number (1234567890.123), quoted float string ("1234567890.123"),
+// and ISO 8601 string ("2026-05-06T03:24:51.099415Z") for cross-language compatibility.
 func (u *UnixTime) UnmarshalJSON(data []byte) error {
 	var seconds float64
 	if err := json.Unmarshal(data, &seconds); err != nil {
@@ -34,11 +35,14 @@ func (u *UnixTime) UnmarshalJSON(data []byte) error {
 		if err2 := json.Unmarshal(data, &s); err2 != nil {
 			return err
 		}
-		f, err3 := strconv.ParseFloat(s, 64)
-		if err3 != nil {
+		if f, err3 := strconv.ParseFloat(s, 64); err3 == nil {
+			seconds = f
+		} else if t, err4 := time.Parse(time.RFC3339Nano, s); err4 == nil {
+			u.Time = t
+			return nil
+		} else {
 			return err3
 		}
-		seconds = f
 	}
 
 	u.Time = time.UnixMicro(int64(seconds * MicrosecondsToSeconds))

--- a/go/types/unix_test.go
+++ b/go/types/unix_test.go
@@ -56,6 +56,22 @@ func TestUnixTimeString(t *testing.T) {
 	}
 }
 
+func TestUnixTimeISO8601(t *testing.T) {
+	t.Log("Running tests for UnixTime with ISO 8601 string input")
+
+	jsonData := `"2026-05-06T03:24:51.099415Z"`
+
+	var ut UnixTime
+	err := json.Unmarshal([]byte(jsonData), &ut)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal UnixTime from ISO 8601 string: %v", err)
+	}
+
+	if ut.Year() != 2026 || ut.Month() != 5 || ut.Day() != 6 {
+		t.Errorf("Expected 2026-05-06, got %v", ut.Time)
+	}
+}
+
 func TestUnixTimeInteger(t *testing.T) {
 	t.Log("Running tests for UnixTime with integer input")
 


### PR DESCRIPTION
## 📋 Summary

- Extends `types.UnixTime.UnmarshalJSON` to accept ISO 8601 datetime strings (e.g. `"2026-05-06T03:24:51.099415Z"`) as a third input form, in addition to bare floats and quoted float strings
- `MarshalJSON` always emits a float — the input form never affects output

## 🐛 Fixes

- Resolves `strconv.ParseFloat: parsing "2026-05-06T03:24:51.099415Z": invalid syntax` decode failures on `outbound.broadcasts.results.v1`, which caused messages to be silently dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)