### PR TITLE
feat: add ZIGBEE_CHANGE action kind (v4.3.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.15
+
+- Added `ActionKind.ZIGBEE_CHANGE` (Python) for actions that send a command to a Zigbee device.
+- Added `zigbee_device_id` and `zigbee_settings` fields to the `Action` entity (Python), carrying the bound connectivity Device ID and the `{device_id, settings: [{key, value}]}` payload for ZIGBEE_CHANGE actions.
+
 ## 4.3.14
 
 - Added `AuthenticatedAsset` entity (Python and Go) with `pk`/`id` and `name` fields.

--- a/python/layrz_sdk/entities/action.py
+++ b/python/layrz_sdk/entities/action.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 from .action_geofence_ownership import ActionGeofenceOwnership
@@ -80,3 +82,13 @@ class Action(BaseModel):
     return ownership.value
 
   owner_id: int | None = Field(default=None, description='Owner ID')
+
+  zigbee_device_id: int | None = Field(
+    default=None,
+    description='Connectivity Device ID bound to the target Zigbee device (only for ZIGBEE_CHANGE)',
+  )
+
+  zigbee_settings: dict[str, Any] | None = Field(
+    default=None,
+    description='Zigbee settings payload: {"device_id": <id>, "settings": [{"key": <expose name>, "value": <typed>}]}',
+  )

--- a/python/layrz_sdk/entities/action_kind.py
+++ b/python/layrz_sdk/entities/action_kind.py
@@ -37,6 +37,9 @@ class ActionKind(StrEnum):
   EXCHANGE = 'EXCHANGE'
   """ Sends the activation to the exchange service """
 
+  ZIGBEE_CHANGE = 'ZIGBEE_CHANGE'
+  """ Sends a command to a Zigbee device """
+
   def __str__(self: Self) -> str:
     """Readable property"""
     return self.name

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "layrz-sdk"
-version = "4.3.14"
+version = "4.3.15"
 description = "Layrz SDK for Python"
 authors = [{ name = "Golden M, Inc.", email = "software@goldenm.com" }]
 requires-python = ">=3.13"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -352,7 +352,7 @@ wheels = [
 
 [[package]]
 name = "layrz-sdk"
-version = "4.3.8"
+version = "4.3.15"
 source = { editable = "." }
 dependencies = [
     { name = "geopy" },


### PR DESCRIPTION
## 📋 Summary

- Adds support for the new `ZIGBEE_CHANGE` action kind, which lets a Layrz Action send a command to a Zigbee device when its trigger fires.
- The Action entity now carries the zigbee execution payload consumed by `layrz-kafka-actions-service`: the bound connectivity Device ID and the `{device_id, settings: [{key, value}]}` settings list.

## 📝 Changes

### ✨ Features
- `ActionKind.ZIGBEE_CHANGE = 'ZIGBEE_CHANGE'` added to the Python `ActionKind` enum.
- `Action` entity (Python): new optional `zigbee_device_id` and `zigbee_settings` fields, defaulting to `None` so existing consumers are unaffected.

### 🔧 Chore / Config
- Version bumped to `4.3.15` with the corresponding `CHANGELOG.md` entry and `uv.lock` refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)