### PR TITLE
chore: bump version to 4.3.16 and update changelog

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: prepare-release
+description: Bump the version, document the changelog, and open a PR from development to main.
+---
+
+# Prepare a release
+
+Bump the version, document the changelog, and open a PR from development to main.
+
+## Usage
+
+/prepare-release <version>
+Where <version> is the new semver string (e.g. 3.6.21).
+
+## Steps
+
+### 1. Validate inputs
+
+- Confirm the working directory is clean (git status). If there are uncommitted changes, stop
+  and tell the user to commit or stash them first.
+- Confirm the current branch is development. If not, stop and warn the user.
+- Confirm <version> is a valid semver string (e.g. 3.6.21, 4.0.0).
+
+### 2. Collect changes since last release
+
+Run:
+git log --oneline <current_version_tag>..HEAD
+or if tags are not present, compare with origin/main:
+git log --oneline origin/main..HEAD
+Read the commit messages to understand what changed. Ignore pure chore/refactor commits
+(e.g. CLAUDE.md updates, code generation runs) unless they are meaningful to library consumers.
+Focus on: new models, new fields, removed/deprecated fields, bug fixes, behaviour changes.
+
+### 3. Update pubspec.yaml
+
+Edit the version: line:
+version: "<version>"
+### 4. Prepend entry to CHANGELOG.md
+
+Insert a new section at the top (after the # Changelog heading) following the existing style:
+## <version>
+
+- <bullet summarising change 1>
+- <bullet summarising change 2>
+Rules:
+- One bullet per logical change (not per commit).
+- Mention model names, field names, and enum values using backticks.
+- Keep bullets concise — one sentence each.
+- Do not include internal/tooling changes (CLAUDE.md, skill files, code generation, etc.).
+
+### 5. Commit the release
+
+Stage only pubspec.yaml and CHANGELOG.md, then commit:
+git add pubspec.yaml CHANGELOG.md
+git commit -m "chore: bump version to <version> and update changelog
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+### 6. Push and open PR
+
+git push origin development
+Then invoke the /pr skill to create the PR. The /pr skill will handle title, body, and reporting the URL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.16
+
+- Fixed `BroadcastStatus.INTERNAL_ERROR` (Go and Python) value to `INTERNALERROR`, matching the platform's actual API response.
+- Added validation to `BroadcastResult.status` and `RawBroadcastResult.status` (Python) that accepts the legacy `INTERNAL_ERROR` string and coerces it to `INTERNALERROR`.
+
 ## 4.3.15
 
 - Added `ActionKind.ZIGBEE_CHANGE` (Python) for actions that send a command to a Zigbee device.

--- a/go/entities/broadcast_status.go
+++ b/go/entities/broadcast_status.go
@@ -5,7 +5,7 @@ type BroadcastStatus string
 const (
 	BroadcastStatusOk                  BroadcastStatus = "OK"
 	BroadcastStatusBadRequest          BroadcastStatus = "BAD_REQUEST"
-	BroadcastStatusInternalError       BroadcastStatus = "INTERNAL_ERROR"
+	BroadcastStatusInternalError       BroadcastStatus = "INTERNALERROR"
 	BroadcastStatusUnauthorized        BroadcastStatus = "UNAUTHORIZED"
 	BroadcastStatusUnprocessableEntity BroadcastStatus = "UNPROCESSABLE"
 	BroadcastStatusDisconnected        BroadcastStatus = "DISCONNECTED"

--- a/python/layrz_sdk/entities/broadcast/result.py
+++ b/python/layrz_sdk/entities/broadcast/result.py
@@ -1,9 +1,11 @@
 """Broadcast result"""
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 from .request import BroadcastRequest
 from .response import BroadcastResponse
@@ -19,6 +21,17 @@ class BroadcastResult(BaseModel):
   request: BroadcastRequest = Field(description='Broadcast request')
   response: BroadcastResponse = Field(description='Broadcast response')
   submitted_at: datetime = Field(description='Broadcast submission date')
+
+  @field_validator('status', mode='before')
+  def validate_status(cls: type[BroadcastResult], value: Any) -> BroadcastStatus:
+    """Validate the status field to ensure it is a valid BroadcastStatus."""
+    if isinstance(value, str) and value == 'INTERNAL_ERROR':
+      value = 'INTERNALERROR'
+    try:
+      return BroadcastStatus(value)
+    except ValueError:
+      pass
+    raise ValueError('Invalid status value. Must be one of: "PENDING", "SUCCESS", "FAILURE", "INTERNALERROR".')
 
 
 class RawBroadcastResult(BaseModel):
@@ -41,6 +54,17 @@ class RawBroadcastResult(BaseModel):
   asset_id: int | None = Field(description='Asset ID')
 
   status: BroadcastStatus = Field(description='Broadcast status')
+
+  @field_validator('status', mode='before')
+  def validate_status(cls: type[RawBroadcastResult], value: Any) -> BroadcastStatus:
+    """Validate the status field to ensure it is a valid BroadcastStatus."""
+    if isinstance(value, str) and value == 'INTERNAL_ERROR':
+      value = 'INTERNALERROR'
+    try:
+      return BroadcastStatus(value)
+    except ValueError:
+      pass
+    raise ValueError('Invalid status value. Must be one of: "PENDING", "SUCCESS", "FAILURE", "INTERNALERROR".')
 
   @field_serializer('status', when_used='always')
   def serialize_status(self, status: BroadcastStatus) -> str:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "layrz-sdk"
-version = "4.3.15"
+version = "4.3.16"
 description = "Layrz SDK for Python"
 authors = [{ name = "Golden M, Inc.", email = "software@goldenm.com" }]
 requires-python = ">=3.13"


### PR DESCRIPTION
## 📋 Summary

- Fixes an entity parity bug where `BroadcastStatus.INTERNAL_ERROR` did not match the platform's actual API response value.
- Bumps version to 4.3.16.

## 📝 Changes

### 🐛 Fixes
- Fixed `BroadcastStatus.INTERNAL_ERROR` (Go and Python) value to `INTERNALERROR`, matching the platform's actual API response.
- Added validation to `BroadcastResult.status` and `RawBroadcastResult.status` (Python) that accepts the legacy `INTERNAL_ERROR` string and coerces it to `INTERNALERROR`.

### 🔧 Chore / Config
- Bumped version to `4.3.16` and updated `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)