### PR TITLE
chore: release 4.3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
-## 4.3.16
+## 4.4.0
 
 - Added `PUSH_NOTIFICATION` value to `OperationType` for Layrz Push (Firebase) operations.
 - Added `push_service_account` (`pushServiceAccount`), `push_devices` (`pushDevices`), and `push_app_id` (`pushAppId`) fields to `OperationPayload` carrying decrypted FCM credentials, bound device UUIDs, and the owning RegisteredApp ID.
+- Go module now provides the shared `OperationPayload` and `OperationType` Kafka wire-contract entities used across Python and Go consumers.
+
+## 4.3.16
+
 - Fixed `BroadcastStatus.INTERNAL_ERROR` (Go and Python) value to `INTERNALERROR`, matching the platform's actual API response.
 - Added validation to `BroadcastResult.status` and `RawBroadcastResult.status` (Python) that accepts the legacy `INTERNAL_ERROR` string and coerces it to `INTERNALERROR`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.3.16
 
+- Added `PUSH_NOTIFICATION` value to `OperationType` for Layrz Push (Firebase) operations.
+- Added `push_service_account` (`pushServiceAccount`), `push_devices` (`pushDevices`), and `push_app_id` (`pushAppId`) fields to `OperationPayload` carrying decrypted FCM credentials, bound device UUIDs, and the owning RegisteredApp ID.
 - Fixed `BroadcastStatus.INTERNAL_ERROR` (Go and Python) value to `INTERNALERROR`, matching the platform's actual API response.
 - Added validation to `BroadcastResult.status` and `RawBroadcastResult.status` (Python) that accepts the legacy `INTERNAL_ERROR` string and coerces it to `INTERNALERROR`.
 

--- a/go/entities/destination_phone.go
+++ b/go/entities/destination_phone.go
@@ -1,0 +1,9 @@
+package entities
+
+// DestinationPhone represents a phone number destination for notifications.
+type DestinationPhone struct {
+	// PhoneNumber is the phone number for the destination.
+	PhoneNumber string `json:"phoneNumber"`
+	// CountryCode is the country code for the phone number.
+	CountryCode string `json:"countryCode"`
+}

--- a/go/entities/operation.go
+++ b/go/entities/operation.go
@@ -1,0 +1,76 @@
+package entities
+
+import (
+	"github.com/goldenm-software/layrz-sdk/go/v4/enums"
+	"github.com/goldenm-software/layrz-sdk/go/v4/types"
+)
+
+// Operation represents an operation configuration.
+type Operation struct {
+	// ID is the unique identifier of the operation.
+	ID int64 `json:"id"`
+	// Name is the name of the operation.
+	Name string `json:"name"`
+	// CooldownTime is the cooldown time in seconds before the operation can be triggered again.
+	CooldownTime types.Duration `json:"cooldown_time"`
+	// OperationType is the type of the operation.
+	OperationType enums.OperationType `json:"operation_type"`
+	// RequestType is the HTTP method for webhook operations.
+	RequestType *enums.HttpRequestType `json:"request_type,omitempty"`
+	// URL is the URL for webhook operations.
+	URL *string `json:"url,omitempty"`
+	// Headers are the HTTP headers for webhook operations.
+	Headers []map[string]any `json:"headers,omitempty"`
+	// ReceptionEmails are the email addresses for email operations.
+	ReceptionEmails []string `json:"reception_emails,omitempty"`
+	// LanguageID is the language identifier for the operation.
+	LanguageID int `json:"language_id"`
+	// Payload is the templated payload string for the operation.
+	Payload string `json:"payload,omitempty"`
+	// TimezoneName is the IANA timezone name for the operation.
+	TimezoneName string `json:"timezone_name"`
+	// DateTimeFormat is the date-time format string for the operation.
+	DateTimeFormat string `json:"date_time_format"`
+	// LayrzTemplate is the Layrz template string for the operation.
+	LayrzTemplate string `json:"layrz_template,omitempty"`
+	// EmailSubject is the subject line for email operations.
+	EmailSubject string `json:"email_subject,omitempty"`
+	// Color is the color associated with the operation in HEX format.
+	Color string `json:"color,omitempty"`
+	// AccountID is the external account ID of the operation.
+	AccountID *int64 `json:"account_id,omitempty"`
+	// NotificationType is the Twilio notification type for Twilio operations.
+	NotificationType enums.TwilioNotificationType `json:"notification_type"`
+	// HostPhone is the host phone number for Twilio operations.
+	HostPhone *DestinationPhone `json:"host_phone,omitempty"`
+	// Username is the username for authentication in some operations.
+	Username *string `json:"username,omitempty"`
+	// Token is the token for authentication in some operations.
+	Token *string `json:"token,omitempty"`
+	// DestinationPhones are the destination phone numbers for Twilio operations.
+	DestinationPhones []DestinationPhone `json:"destination_phones,omitempty"`
+	// AttachImage indicates if the operation should attach an image.
+	AttachImage bool `json:"attach_image"`
+	// UseAssetContactsInstead indicates if the operation should use asset contacts instead of reception emails.
+	UseAssetContactsInstead bool `json:"use_asset_contacts_instead"`
+	// EmailTemplateID is the email template ID for email operations.
+	EmailTemplateID *int64 `json:"email_template_id,omitempty"`
+	// PushPlatforms are the platforms for push notifications.
+	PushPlatforms []enums.Platform `json:"push_platforms,omitempty"`
+	// PushTitle is the title for push notifications.
+	PushTitle string `json:"push_title,omitempty"`
+	// RequiresBhsValidation indicates if the operation requires BHS validation.
+	RequiresBhsValidation bool `json:"requires_bhs_validation"`
+	// BhsTierID is the BHS tier ID for the operation.
+	BhsTierID *int64 `json:"bhs_tier_id,omitempty"`
+	// SoundEffect is the sound effect for the operation.
+	SoundEffect enums.SoundEffect `json:"sound_effect"`
+	// SoundEffectURI is the URI for custom sound effects.
+	SoundEffectURI *string `json:"sound_effect_uri,omitempty"`
+	// Duration is the duration of the operation in seconds.
+	Duration *types.Duration `json:"duration,omitempty"`
+	// Credentials is a map of credentials for the operation.
+	Credentials map[string]any `json:"credentials,omitempty"`
+	// Icon is the icon for the operation.
+	Icon *string `json:"icon,omitempty"`
+}

--- a/go/entities/operation_case.go
+++ b/go/entities/operation_case.go
@@ -1,0 +1,33 @@
+package entities
+
+import "github.com/goldenm-software/layrz-sdk/go/v4/types"
+
+// OperationCaseComment represents a comment on an operation case.
+type OperationCaseComment struct {
+	// ID is the unique identifier of the case comment.
+	ID int64 `json:"id"`
+	// User is the user who created the comment.
+	User string `json:"user"`
+	// Content is the content of the comment.
+	Content string `json:"content"`
+	// CreatedAt is the timestamp when the comment was created.
+	CreatedAt types.UnixTime `json:"created_at"`
+}
+
+// OperationCase represents a case associated with an operation.
+type OperationCase struct {
+	// ID is the unique identifier of the case.
+	ID int64 `json:"id"`
+	// CreatedAt is the timestamp when the case was created.
+	CreatedAt types.UnixTime `json:"created_at"`
+	// UpdatedAt is the timestamp when the case was last updated.
+	UpdatedAt types.UnixTime `json:"updated_at"`
+	// Trigger is the trigger associated with the case.
+	Trigger *Trigger `json:"trigger,omitempty"`
+	// FileID is the identifier of the file associated with the case, if any.
+	FileID *int64 `json:"file_id,omitempty"`
+	// FileCreatedAt is the timestamp when the file was created, if applicable.
+	FileCreatedAt *types.UnixTime `json:"file_created_at,omitempty"`
+	// Comment is the comment associated with the case, if any.
+	Comment *OperationCaseComment `json:"comment,omitempty"`
+}

--- a/go/entities/operation_payload.go
+++ b/go/entities/operation_payload.go
@@ -1,0 +1,104 @@
+package entities
+
+import (
+	"encoding/json"
+
+	"github.com/goldenm-software/layrz-sdk/go/v4/enums"
+	"github.com/goldenm-software/layrz-sdk/go/v4/types"
+)
+
+// OperationPayload represents a message produced to the operations.runner.v1 Kafka topic.
+type OperationPayload struct {
+	// Kind defines the type of the operation (wire key: operationType).
+	Kind enums.OperationType `json:"operationType"`
+	// Asset is the asset associated with the operation.
+	Asset *Asset `json:"asset,omitempty"`
+	// Trigger is the trigger associated with the operation.
+	Trigger *Trigger `json:"trigger,omitempty"`
+	// Operation is the operation to be executed.
+	Operation *Operation `json:"operation,omitempty"`
+	// ActivatedAt is the timestamp when the operation was activated (wire key: activatedAt).
+	ActivatedAt types.UnixTime `json:"activatedAt"`
+	// Position contains the current position data of the asset.
+	Position map[string]any `json:"position,omitempty"`
+	// Sensors contains the current sensor readings of the asset.
+	Sensors map[string]any `json:"sensors,omitempty"`
+	// Geofence is the geofence associated with the operation, if any.
+	Geofence *Geofence `json:"geofence,omitempty"`
+	// PresenceType indicates the type of geofence presence event (wire key: presenceType).
+	PresenceType *enums.PresenceType `json:"presenceType,omitempty"`
+	// Case is the case associated with the operation, if any (wire key: case).
+	Case *OperationCase `json:"case,omitempty"`
+	// LanguageID is the language identifier for the operation (wire key: languageId).
+	LanguageID int `json:"languageId"`
+	// Payload is the templated payload string for the operation.
+	Payload string `json:"payload,omitempty"`
+	// UseAssetContactsInstead indicates if the operation should use asset
+	// contacts instead of reception emails (wire key: useAssetContactsInstead).
+	UseAssetContactsInstead bool `json:"useAssetContactsInstead"`
+	// AccountID is the external account ID of the operation (wire key: accountId).
+	AccountID *int64 `json:"accountId,omitempty"`
+
+	// HTTP/Webhook fields
+	// HttpURL is the URL for HTTP webhook operations.
+	HttpURL *string `json:"http_url,omitempty"`
+	// HttpMethod is the HTTP method for webhook operations (wire key: method).
+	HttpMethod *enums.HttpRequestType `json:"method,omitempty"`
+	// HttpHeaders are the HTTP headers for webhook operations (wire key: headers).
+	HttpHeaders []map[string]any `json:"headers,omitempty"`
+
+	// Email fields
+	// EmailSubject is the subject line for email operations (wire key: emailSubject).
+	EmailSubject string `json:"emailSubject,omitempty"`
+	// AttachImage indicates if the operation should attach an image to emails (wire key: attachImage).
+	AttachImage bool `json:"attachImage"`
+	// ReceptionEmails are the email addresses to send to (wire key: receptionEmails).
+	ReceptionEmails []string `json:"receptionEmails,omitempty"`
+	// TemplateID is the email template ID (wire key: templateId).
+	TemplateID *int64 `json:"templateId,omitempty"`
+
+	// Twilio/Phone fields
+	// Destinations are the phone number destinations for Twilio notifications.
+	Destinations []DestinationPhone `json:"destinations,omitempty"`
+	// TwilioHostPhone is the host phone number for Twilio operations (wire key: hostPhone).
+	TwilioHostPhone *DestinationPhone `json:"hostPhone,omitempty"`
+	// TwilioNotificationType is the type of Twilio notification (wire key: notificationType).
+	TwilioNotificationType enums.TwilioNotificationType `json:"notificationType"`
+	// Username is the username for authentication in some operations.
+	Username *string `json:"username,omitempty"`
+	// Token is the token for authentication in some operations.
+	Token *string `json:"token,omitempty"`
+
+	// BHS validation fields
+	// RequiresBhsValidation indicates if the operation requires BHS validation (wire key: requiresBhsValidation).
+	RequiresBhsValidation bool `json:"requiresBhsValidation"`
+	// BhsTierID is the BHS tier ID for the operation (wire key: bhsTierId).
+	BhsTierID *int64 `json:"bhsTierId,omitempty"`
+
+	// Push notification fields
+	// PushTitle is the title for push notifications (wire key: pushTitle).
+	PushTitle string `json:"pushTitle,omitempty"`
+	// PushPlatforms are the platforms for push notifications (wire key: pushPlatforms).
+	PushPlatforms []enums.Platform `json:"pushPlatforms,omitempty"`
+	// PushServiceAccount is the decrypted Firebase service-account JSON for Layrz Push (wire key: pushServiceAccount).
+	PushServiceAccount json.RawMessage `json:"pushServiceAccount,omitempty"`
+	// PushDevices are the push device UUIDs for the operation (wire key: pushDevices).
+	PushDevices []string `json:"pushDevices,omitempty"`
+	// PushAppID is the registered app ID owning the push credentials (wire key: pushAppId).
+	PushAppID *int64 `json:"pushAppId,omitempty"`
+
+	// In-app notification fields
+	// DestinationsIDs are the destination IDs for in-app notifications (wire key: destinationsIds).
+	DestinationsIDs []int64 `json:"destinationsIds,omitempty"`
+	// SoundEffect is the sound effect for the operation (wire key: soundEffect).
+	SoundEffect enums.SoundEffect `json:"soundEffect"`
+	// SoundEffectURI is the URI for custom sound effects (wire key: soundEffectUri).
+	SoundEffectURI *string `json:"soundEffectUri,omitempty"`
+	// Icon is the icon for the in-app notification.
+	Icon *string `json:"icon,omitempty"`
+	// Duration is the display duration of the in-app notification in seconds (wire key: duration).
+	Duration *types.Duration `json:"duration,omitempty"`
+
+	// Locator is the generated locator for the operation, if any.
+	Locator *Locator `json:"locator,omitempty"`
+}

--- a/go/entities/operation_payload_test.go
+++ b/go/entities/operation_payload_test.go
@@ -1,0 +1,61 @@
+package entities
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/goldenm-software/layrz-sdk/go/v4/enums"
+	"github.com/goldenm-software/layrz-sdk/go/v4/types"
+)
+
+func TestOperationPayloadMarshalJSON(t *testing.T) {
+	now := types.UnixTime{}
+	now.UnmarshalJSON([]byte("1234567890.5"))
+
+	payload := &OperationPayload{
+		Kind:        enums.OperationTypeWebhooks,
+		ActivatedAt: now,
+		LanguageID:  2,
+		Payload:     "test payload",
+		Asset: &Asset{
+			Id:            1,
+			Name:          "Test Asset",
+			OperationMode: enums.AssetOperationModeSingle,
+		},
+		HttpURL:    strPtr("https://example.com/webhook"),
+		HttpMethod: (*enums.HttpRequestType)(strPtr("POST")),
+	}
+
+	// Test marshaling
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	// Verify key names in JSON
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// Check wire key names (aliases)
+	if _, ok := m["operationType"]; !ok {
+		t.Error("expected 'operationType' key in JSON")
+	}
+	if _, ok := m["activatedAt"]; !ok {
+		t.Error("expected 'activatedAt' key in JSON")
+	}
+	if _, ok := m["languageId"]; !ok {
+		t.Error("expected 'languageId' key in JSON")
+	}
+	if _, ok := m["method"]; !ok {
+		t.Error("expected 'method' key in JSON (HTTP method alias)")
+	}
+	if _, ok := m["http_url"]; !ok {
+		t.Error("expected 'http_url' key in JSON (no alias for http_url)")
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/go/enums/operation_type.go
+++ b/go/enums/operation_type.go
@@ -1,0 +1,29 @@
+package enums
+
+// OperationType represents the type of operation to be executed.
+type OperationType string
+
+const (
+	// OperationTypeWebhooks sends an HTTP request to a webhook endpoint.
+	OperationTypeWebhooks OperationType = "WEBHOOKS"
+	// OperationTypeSendEmail sends an email notification.
+	OperationTypeSendEmail OperationType = "SENDEMAIL"
+	// OperationTypeRegisterOnAsset registers an event on an asset.
+	OperationTypeRegisterOnAsset OperationType = "ACTIVATEASSET"
+	// OperationTypeInAppNotification sends an in-app notification.
+	OperationTypeInAppNotification OperationType = "INAPPNOTIFICATION"
+	// OperationTypeTwilio sends a notification via Twilio.
+	OperationTypeTwilio OperationType = "TWILIO"
+	// OperationTypeMobilePopupNotification sends a mobile popup notification.
+	OperationTypeMobilePopupNotification OperationType = "MOBILE_POPUP_NOTIFICATION"
+	// OperationTypeBhsPush sends a Firebase push notification via BHS.
+	OperationTypeBhsPush OperationType = "BHS_PUSH"
+	// OperationTypePushNotification sends a Layrz push notification to registered devices.
+	OperationTypePushNotification OperationType = "PUSH_NOTIFICATION"
+	// OperationTypeSMS sends an SMS via Layrz notification engine.
+	OperationTypeSMS OperationType = "SMS"
+	// OperationTypeVoiceCall makes a voice call via Layrz notification engine.
+	OperationTypeVoiceCall OperationType = "VOICE_CALL"
+	// OperationTypeWhatsAppMessage sends a WhatsApp message via Layrz notification engine.
+	OperationTypeWhatsAppMessage OperationType = "WHATSAPP_MESSAGE"
+)

--- a/go/enums/twilio_notification_type.go
+++ b/go/enums/twilio_notification_type.go
@@ -1,0 +1,13 @@
+package enums
+
+// TwilioNotificationType represents the type of Twilio notification.
+type TwilioNotificationType string
+
+const (
+	// TwilioNotificationTypeSMS sends a Short Message Service (SMS) notification.
+	TwilioNotificationTypeSMS TwilioNotificationType = "SMS"
+	// TwilioNotificationTypeVoice makes a voice call notification.
+	TwilioNotificationTypeVoice TwilioNotificationType = "VOICE"
+	// TwilioNotificationTypeWhatsApp sends a WhatsApp notification.
+	TwilioNotificationTypeWhatsApp TwilioNotificationType = "WHATSAPP"
+)

--- a/python/layrz_sdk/entities/operation_payload.py
+++ b/python/layrz_sdk/entities/operation_payload.py
@@ -288,6 +288,24 @@ class OperationPayload(BaseModel):
   def serialize_push_platforms(self, value: list[Platform]) -> list[str]:
     return [platform.value for platform in value]
 
+  push_service_account: dict[str, Any] | None = Field(
+    default=None,
+    description='Defines the decrypted Firebase service-account JSON used to send Layrz Push notifications',
+    alias='pushServiceAccount',
+  )
+
+  push_devices: list[str] = Field(
+    default_factory=list,
+    description='Defines the PushDevice UUIDs bound to the operation',
+    alias='pushDevices',
+  )
+
+  push_app_id: int | None = Field(
+    default=None,
+    description='Defines the RegisteredApp ID owning the push credentials',
+    alias='pushAppId',
+  )
+
   ## For usage of In-app notifications operations
   destinations_ids: list[int] = Field(
     default_factory=list,

--- a/python/layrz_sdk/entities/operation_type.py
+++ b/python/layrz_sdk/entities/operation_type.py
@@ -28,6 +28,9 @@ class OperationType(StrEnum):
   BHS_PUSH = 'BHS_PUSH'
   """ Send notifications using Firebase Push Notifications of Brickhouse Tracking Platform """
 
+  PUSH_NOTIFICATION = 'PUSH_NOTIFICATION'
+  """ Send notifications using Layrz Push (Firebase) to registered devices """
+
   SMS = 'SMS'
   """ Send notifications using SMS from Layrz Notification engine """
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "layrz-sdk"
-version = "4.3.16"
+version = "4.4.0"
 description = "Layrz SDK for Python"
 authors = [{ name = "Golden M, Inc.", email = "software@goldenm.com" }]
 requires-python = ">=3.13"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -352,7 +352,7 @@ wheels = [
 
 [[package]]
 name = "layrz-sdk"
-version = "4.3.16"
+version = "4.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "geopy" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -352,7 +352,7 @@ wheels = [
 
 [[package]]
 name = "layrz-sdk"
-version = "4.3.15"
+version = "4.3.16"
 source = { editable = "." }
 dependencies = [
     { name = "geopy" },


### PR DESCRIPTION
## 📋 Summary

Release 4.3.16 of layrz-sdk adds `PUSH_NOTIFICATION` operation type and related Firebase credentials fields to support Layrz Push notifications. Includes a critical fix for `BroadcastStatus.INTERNAL_ERROR` value coercion.

## 📝 Changes

### ✨ Features
- Added `PUSH_NOTIFICATION` value to `OperationType` for Layrz Push (Firebase) operations
- Added `push_service_account` (`pushServiceAccount`), `push_devices` (`pushDevices`), and `push_app_id` (`pushAppId`) fields to `OperationPayload` carrying decrypted FCM credentials, bound device UUIDs, and the owning RegisteredApp ID

### 🐛 Fixes
- Fixed `BroadcastStatus.INTERNAL_ERROR` (Go and Python) value to `INTERNALERROR`, matching the platform's actual API response
- Added validation to `BroadcastResult.status` and `RawBroadcastResult.status` (Python) that accepts the legacy `INTERNAL_ERROR` string and coerces it to `INTERNALERROR`

### 🔧 Chore / Config
- Updated CHANGELOG.md for version 4.3.16
- Updated uv.lock