### PR TITLE
chore: bump version to 4.4.1 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.4.1
+
+- Fixed `BroadcastStatus.BAD_REQUEST` (Go and Python) value to `BAD_REQUEST`, matching the platform's actual API response (was incorrectly `BADREQUEST`).
+- Added validation to `BroadcastResult.status` (Python) that accepts the legacy `BADREQUEST` string and coerces it to `BAD_REQUEST`.
+
 ## 4.4.0
 
 - Added `PUSH_NOTIFICATION` value to `OperationType` for Layrz Push (Firebase) operations.

--- a/go/enums/broadcast_status.go
+++ b/go/enums/broadcast_status.go
@@ -4,7 +4,7 @@ type BroadcastStatus string
 
 const (
 	BroadcastStatusOk            BroadcastStatus = "OK"
-	BroadcastStatusBad_Request   BroadcastStatus = "BADREQUEST"
+	BroadcastStatusBad_Request   BroadcastStatus = "BAD_REQUEST"
 	BroadcastStatusInternalError BroadcastStatus = "INTERNALERROR"
 	BroadcastStatusUnauthorized  BroadcastStatus = "UNAUTHORIZED"
 	BroadcastStatusUnprocessable BroadcastStatus = "UNPROCESSABLE"

--- a/python/layrz_sdk/entities/broadcast/result.py
+++ b/python/layrz_sdk/entities/broadcast/result.py
@@ -27,11 +27,18 @@ class BroadcastResult(BaseModel):
     """Validate the status field to ensure it is a valid BroadcastStatus."""
     if isinstance(value, str) and value == 'INTERNAL_ERROR':
       value = 'INTERNALERROR'
+    if isinstance(value, str) and value == 'BADREQUEST':
+      value = 'BAD_REQUEST'
     try:
       return BroadcastStatus(value)
     except ValueError:
       pass
-    raise ValueError('Invalid status value. Must be one of: "PENDING", "SUCCESS", "FAILURE", "INTERNALERROR".')
+    raise ValueError(
+      """
+      Invalid status value. Must be one of: "BAD_REQUEST", "INTERNALERROR",
+      "UNAUTHORIZED", "UNPROCESSABLE", "DISCONNECTED".
+      """
+    )
 
 
 class RawBroadcastResult(BaseModel):

--- a/python/layrz_sdk/entities/broadcast/status.py
+++ b/python/layrz_sdk/entities/broadcast/status.py
@@ -8,7 +8,7 @@ class BroadcastStatus(StrEnum):
   """Broadcast result status"""
 
   OK = 'OK'
-  BAD_REQUEST = 'BADREQUEST'
+  BAD_REQUEST = 'BAD_REQUEST'
   INTERNAL_ERROR = 'INTERNALERROR'
   UNAUTHORIZED = 'UNAUTHORIZED'
   UNPROCESSABLE = 'UNPROCESSABLE'

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "layrz-sdk"
-version = "4.4.0"
+version = "4.4.1"
 description = "Layrz SDK for Python"
 authors = [{ name = "Golden M, Inc.", email = "software@goldenm.com" }]
 requires-python = ">=3.13"


### PR DESCRIPTION
## 📋 Summary

- Fixes an entity parity bug where `BroadcastStatus.BAD_REQUEST` did not match the platform's actual API response value.
- Bumps version to 4.4.1.

## 📝 Changes

### 🐛 Fixes
- Fixed `BroadcastStatus.BAD_REQUEST` (Go and Python) value to `BAD_REQUEST`, matching the platform's actual API response (was incorrectly `BADREQUEST`).
- Added validation to `BroadcastResult.status` (Python) that accepts the legacy `BADREQUEST` string and coerces it to `BAD_REQUEST`.

### 🔧 Chore / Config
- Bumped version to `4.4.1` and updated `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)